### PR TITLE
Handle OpenSession as session-less PTP operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,27 +116,27 @@ honestly, any) library.
 **Workarounds:**
 
 1. **Kill loop**: Run this in Terminal while using your app:
-   ```bash
+  ```bash
    while true; do pkill -9 ptpcamerad 2>/dev/null; sleep 1; done
-   ```
+  ```
 
 2. **Disable `ptpcamerad`**: Persistent, but may break Photos.app:
 
-   ```bash
+  ```bash
    sudo launchctl disable system/com.apple.ptpcamerad
-   ```
+  ```
 
 **Other tips for app developers:**
 
 - This library provides `Error::is_exclusive_access()`. Use this to detect this condition and guide users to apply
-  one of the workarounds above.
+one of the workarounds above.
 - Query IORegistry for `UsbExclusiveOwner` to show which process (pid, name) holds the device for even more helpful info
 - App Store sandboxed apps cannot kill processes. If your app is such, then provide the command for users to run
-  manually.
-  If your app isn't in the App Store, then you're in a better position and may be able to use the workarounds, BUT
-  it's a bit murky territory with Apple.
+manually.
+If your app isn't in the App Store, then you're in a better position and may be able to use the workarounds, BUT
+it's a bit murky territory with Apple.
 - See [Cmdr](https://github.com/vdavid/cmdr) and [Commander One](https://mac.eltima.com/file-manager.html) for UX
-  inspiration on handling this gracefully.
+inspiration on handling this gracefully.
 
 #### Windows
 
@@ -262,19 +262,19 @@ We use `nusb` for USB access, which is also runtime-agnostic.
 Android's MTP implementation has some quirks that this library handles automatically:
 
 - **Behavior:** Recursive listing broken
-    - **What happens:** `ObjectHandle::ALL` returns incomplete results (folders only, no files)
-    - **How we handle it:** Auto-detected; uses manual folder traversal instead. Although, note that it takes a lot more
-      time! Like, if the device supported this, it'd be pretty fast, while with the workaround, in the tests it took
-      9 minutes to list ~20k files in ~2k folders.
+  - **What happens:** `ObjectHandle::ALL` returns incomplete results (folders only, no files)
+  - **How we handle it:** Auto-detected; uses manual folder traversal instead. Although, note that it takes a lot more
+  time! Like, if the device supported this, it'd be pretty fast, while with the workaround, in the tests it took
+  9 minutes to list ~20k files in ~2k folders.
 - **Behavior:** Can't create in root
-    - **What happens:** Creating files/folders in storage root fails with `InvalidObjectHandle`
-    - **How we handle it:** Use a subfolder like `Download/` as the parent
+  - **What happens:** Creating files/folders in storage root fails with `InvalidObjectHandle`
+  - **How we handle it:** Use a subfolder like `Download/` as the parent
 - **Behavior:** Large responses span transfers
-    - **What happens:** Data >64KB comes in multiple USB transfers
-    - **How we handle it:** Automatically reassembled before parsing
+  - **What happens:** Data >64KB comes in multiple USB transfers
+  - **How we handle it:** Automatically reassembled before parsing
 - **Behavior:** Composite USB devices
-    - **What happens:** Most phones report as USB class 0 (composite)
-    - **How we handle it:** We inspect interfaces to find MTP
+  - **What happens:** Most phones report as USB class 0 (composite)
+  - **How we handle it:** We inspect interfaces to find MTP
 
 The library detects Android devices via the `"android.com"` vendor extension and applies appropriate handling
 automatically.
@@ -295,10 +295,13 @@ storage.upload(Some(download.handle), file_info, data).await?;
 
 "Full support" really means "Full support, except for general Android quirks listed above".
 
-| Device                              | Android | Notes           |
-|-------------------------------------|---------|-----------------|
-| Google Pixel 9 Pro XL               | 15      | Full support    |
-| Samsung Galaxy S23 Ultra (SM-S918B) | 14      | No root listing |
+
+| Device                                              | Android | Notes           |
+| --------------------------------------------------- | ------- | --------------- |
+| Google Pixel 9 Pro XL                               | 15      | Full support    |
+| Samsung Galaxy S23 Ultra (SM-S918B)                 | 14      | No root listing |
+| Amazon Kindle Paperwhite 12th Generation (2024)     | -       | Full support    |
+
 
 **Samsung quirk**: Samsung devices return `InvalidObjectHandle` when listing the root folder with handle 0.
 The library automatically detects this and falls back to recursive listing with filtering. This is transparent to users.
@@ -361,17 +364,17 @@ macOS, and Windows.
 ## Implementation notes
 
 - I used Opus 4.5 extensively for this implementation. I know it's controversial these days, but the bottom line to me
-  is that the implementation WORKS, it has a bunch of integration tests which pass, and hey, I can use it to copy data
-  to/from my phone and other phones and I can display async progress and I don't need to rely on C libraries. So no
-  hate,
-  please. If you dislike or distrust AI-gen code, use the alternatives listed above (if you can live with the libmtp
-  dependency), handcraft your own Rust implementation, or fork this repo and add your human thing and use it.
-  PRs are also welcome.
+is that the implementation WORKS, it has a bunch of integration tests which pass, and hey, I can use it to copy data
+to/from my phone and other phones and I can display async progress and I don't need to rely on C libraries. So no
+hate,
+please. If you dislike or distrust AI-gen code, use the alternatives listed above (if you can live with the libmtp
+dependency), handcraft your own Rust implementation, or fork this repo and add your human thing and use it.
+PRs are also welcome.
 - For the protocol spec, I tried to use
-  usb.org's [Media Transfer Protocol v.1.1 Spec](https://www.usb.org/document-library/media-transfer-protocol-v11-spec-and-mtp-v11-adopters-agreement),
-  but it was a pain to get AI agents to work from it, so I've converted it to Markdown. You can find it
+usb.org's [Media Transfer Protocol v.1.1 Spec](https://www.usb.org/document-library/media-transfer-protocol-v11-spec-and-mtp-v11-adopters-agreement),
+but it was a pain to get AI agents to work from it, so I've converted it to Markdown. You can find it
   here: https://github.com/vdavid/mtp-v1_1-spec-md
-  I've also shared it back with the USB.org team, so they might link it on the official page.
+I've also shared it back with the USB.org team, so they might link it on the official page.
 
 ## Contributing
 

--- a/src/mtp/storage.rs
+++ b/src/mtp/storage.rs
@@ -640,12 +640,12 @@ mod tests {
     #[tokio::test]
     async fn stream_returns_objects_with_correct_counters() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
-        queue_handles(&mock, 2, &[10, 20, 30]);
-        queue_object_info(&mock, 3, "photo.jpg", 0);
-        queue_object_info(&mock, 4, "video.mp4", 0);
-        queue_object_info(&mock, 5, "notes.txt", 0);
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "photo.jpg", 0);
+        queue_object_info(&mock, 3, "video.mp4", 0);
+        queue_object_info(&mock, 4, "notes.txt", 0);
 
         let storage = mock_storage(transport, "").await;
         let mut listing = storage.list_objects_stream(None).await.unwrap();
@@ -674,8 +674,8 @@ mod tests {
     #[tokio::test]
     async fn stream_empty_directory() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        queue_handles(&mock, 2, &[]);
+        mock.queue_response(ok_response(0)); // OpenSession
+        queue_handles(&mock, 1, &[]);
 
         let storage = mock_storage(transport, "").await;
         let mut listing = storage.list_objects_stream(None).await.unwrap();
@@ -688,12 +688,12 @@ mod tests {
     async fn stream_filters_by_parent() {
         // Simulates Fuji quirk: device returns objects with wrong parent handles
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
-        queue_handles(&mock, 2, &[10, 20, 30]);
-        queue_object_info(&mock, 3, "root_file.jpg", 0); // parent=ROOT, included
-        queue_object_info(&mock, 4, "nested.jpg", 99); // parent=99, filtered out
-        queue_object_info(&mock, 5, "another_root.txt", 0); // parent=ROOT, included
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "root_file.jpg", 0); // parent=ROOT, included
+        queue_object_info(&mock, 3, "nested.jpg", 99); // parent=99, filtered out
+        queue_object_info(&mock, 4, "another_root.txt", 0); // parent=ROOT, included
 
         let storage = mock_storage(transport, "").await;
         let mut listing = storage.list_objects_stream(None).await.unwrap();
@@ -715,12 +715,12 @@ mod tests {
     async fn stream_android_root_accepts_both_parents() {
         // Android quirk: root items may have parent 0 or 0xFFFFFFFF
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
-        queue_handles(&mock, 2, &[10, 20, 30]);
-        queue_object_info(&mock, 3, "dcim", 0); // parent=0, root
-        queue_object_info(&mock, 4, "download", 0xFFFFFFFF); // parent=ALL, also root on Android
-        queue_object_info(&mock, 5, "nested", 42); // not root
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "dcim", 0); // parent=0, root
+        queue_object_info(&mock, 3, "download", 0xFFFFFFFF); // parent=ALL, also root on Android
+        queue_object_info(&mock, 4, "nested", 42); // not root
 
         let storage = mock_storage(transport, "android.com").await;
         let mut listing = storage.list_objects_stream(None).await.unwrap();
@@ -737,12 +737,12 @@ mod tests {
     #[tokio::test]
     async fn stream_subfolder_listing() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         let parent_handle = 42u32;
-        queue_handles(&mock, 2, &[100, 101]);
-        queue_object_info(&mock, 3, "IMG_001.jpg", parent_handle);
-        queue_object_info(&mock, 4, "IMG_002.jpg", parent_handle);
+        queue_handles(&mock, 1, &[100, 101]);
+        queue_object_info(&mock, 2, "IMG_001.jpg", parent_handle);
+        queue_object_info(&mock, 3, "IMG_002.jpg", parent_handle);
 
         let storage = mock_storage(transport, "").await;
         let mut listing = storage
@@ -761,12 +761,12 @@ mod tests {
     #[tokio::test]
     async fn stream_propagates_mid_listing_error() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
-        queue_handles(&mock, 2, &[10, 20]);
-        queue_object_info(&mock, 3, "good.jpg", 0);
+        queue_handles(&mock, 1, &[10, 20]);
+        queue_object_info(&mock, 2, "good.jpg", 0);
         // Handle 20: device returns error instead of object info
-        mock.queue_response(error_response(4, ResponseCode::InvalidObjectHandle));
+        mock.queue_response(error_response(3, ResponseCode::InvalidObjectHandle));
 
         let storage = mock_storage(transport, "").await;
         let mut listing = storage.list_objects_stream(None).await.unwrap();
@@ -785,10 +785,10 @@ mod tests {
         let (transport2, mock2) = mock_transport();
 
         for mock in [&mock1, &mock2] {
-            mock.queue_response(ok_response(1)); // OpenSession
-            queue_handles(mock, 2, &[10, 20]);
-            queue_object_info(mock, 3, "a.jpg", 0);
-            queue_object_info(mock, 4, "b.txt", 0);
+            mock.queue_response(ok_response(0)); // OpenSession
+            queue_handles(mock, 1, &[10, 20]);
+            queue_object_info(mock, 2, "a.jpg", 0);
+            queue_object_info(mock, 3, "b.txt", 0);
         }
 
         let storage1 = mock_storage(transport1, "").await;

--- a/src/ptp/session/mod.rs
+++ b/src/ptp/session/mod.rs
@@ -86,10 +86,10 @@ impl PtpSession {
     pub async fn open(transport: Arc<dyn Transport>, session_id: u32) -> Result<Self, Error> {
         let session = Self::new(transport, SessionId(session_id));
 
-        // Send OpenSession command
-        let response = session
-            .execute(OperationCode::OpenSession, &[session_id])
-            .await?;
+        // PTP spec: OpenSession is a session-less operation, so use tx_id=0.
+        // Some devices (e.g. Amazon Kindle) enforce this strictly and reject
+        // OpenSession with tx_id != 0 as InvalidParameter.
+        let response = Self::send_open_session(&session.transport, session_id).await?;
 
         if response.code == ResponseCode::Ok {
             return Ok(session);
@@ -103,9 +103,8 @@ impl PtpSession {
             // Create a new session instance with reset transaction ID counter
             let fresh_session = Self::new(Arc::clone(&session.transport), SessionId(session_id));
 
-            let retry_response = fresh_session
-                .execute(OperationCode::OpenSession, &[session_id])
-                .await?;
+            let retry_response =
+                Self::send_open_session(&fresh_session.transport, session_id).await?;
 
             if retry_response.code != ResponseCode::Ok {
                 return Err(Error::Protocol {
@@ -121,6 +120,22 @@ impl PtpSession {
             code: response.code,
             operation: OperationCode::OpenSession,
         })
+    }
+
+    /// Send OpenSession with transaction_id=0 (SESSION_LESS) per the PTP spec.
+    async fn send_open_session(
+        transport: &Arc<dyn Transport>,
+        session_id: u32,
+    ) -> Result<ResponseContainer, Error> {
+        let cmd = CommandContainer {
+            code: OperationCode::OpenSession,
+            transaction_id: TransactionId::SESSION_LESS.0,
+            params: vec![session_id],
+        };
+        transport.send_bulk(&cmd.to_bytes()).await?;
+
+        let response_bytes = transport.receive_bulk(512).await?;
+        ResponseContainer::from_bytes(&response_bytes)
     }
 
     /// Get the session ID.

--- a/src/ptp/session/mod.rs
+++ b/src/ptp/session/mod.rs
@@ -391,7 +391,7 @@ mod tests {
     #[tokio::test]
     async fn test_open_session() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1));
+        mock.queue_response(ok_response(0)); // OpenSession is session-less (tx_id=0)
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         assert_eq!(session.session_id(), SessionId(1));
@@ -401,16 +401,16 @@ mod tests {
     async fn test_open_session_already_open_recovers() {
         let (transport, mock) = mock_transport();
 
-        // First OpenSession returns SessionAlreadyOpen
+        // First OpenSession returns SessionAlreadyOpen (session-less, tx_id=0)
         mock.queue_response(response_with_params(
-            1,
+            0,
             ResponseCode::SessionAlreadyOpen,
             &[],
         ));
-        // CloseSession response (ignored, but we need to provide one)
-        mock.queue_response(ok_response(2));
-        // Second OpenSession (fresh session, tx_id starts at 1 again)
+        // CloseSession (tx_id=1, first counter value)
         mock.queue_response(ok_response(1));
+        // Second OpenSession on fresh session (session-less, tx_id=0)
+        mock.queue_response(ok_response(0));
 
         // Should succeed by closing and reopening
         let session = PtpSession::open(transport, 1).await.unwrap();
@@ -421,23 +421,22 @@ mod tests {
     async fn test_open_session_already_open_transaction_id_reset() {
         let (transport, mock) = mock_transport();
 
-        // First OpenSession returns SessionAlreadyOpen
+        // First OpenSession returns SessionAlreadyOpen (session-less, tx_id=0)
         mock.queue_response(response_with_params(
-            1,
+            0,
             ResponseCode::SessionAlreadyOpen,
             &[],
         ));
-        // CloseSession response
-        mock.queue_response(ok_response(2));
-        // Second OpenSession (fresh session, tx_id starts at 1 again)
+        // CloseSession uses tx_id=1 (first counter value, OpenSession didn't consume one)
         mock.queue_response(ok_response(1));
-        // Next operation should use tx_id = 2 (after the fresh OpenSession used 1)
-        mock.queue_response(ok_response(2));
+        // Second OpenSession on fresh session (session-less, tx_id=0)
+        mock.queue_response(ok_response(0));
+        // First operation on fresh session uses tx_id=1
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
 
-        // Perform an operation to verify transaction ID is properly reset
-        // The next operation should use tx_id = 2 (since the fresh OpenSession used 1)
+        // Verify the fresh session's counter starts at 1
         session.delete_object(ObjectHandle(1)).await.unwrap();
     }
 
@@ -445,16 +444,16 @@ mod tests {
     async fn test_open_session_already_open_close_error_ignored() {
         let (transport, mock) = mock_transport();
 
-        // First OpenSession returns SessionAlreadyOpen
+        // First OpenSession returns SessionAlreadyOpen (session-less, tx_id=0)
         mock.queue_response(response_with_params(
-            1,
+            0,
             ResponseCode::SessionAlreadyOpen,
             &[],
         ));
-        // CloseSession returns an error (should be ignored)
-        mock.queue_response(response_with_params(2, ResponseCode::GeneralError, &[]));
-        // Second OpenSession succeeds
-        mock.queue_response(ok_response(1));
+        // CloseSession returns an error (tx_id=1, should be ignored)
+        mock.queue_response(response_with_params(1, ResponseCode::GeneralError, &[]));
+        // Second OpenSession succeeds (session-less, tx_id=0)
+        mock.queue_response(ok_response(0));
 
         // Should succeed even if CloseSession fails
         let session = PtpSession::open(transport, 1).await.unwrap();
@@ -464,7 +463,7 @@ mod tests {
     #[tokio::test]
     async fn test_open_session_error() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(response_with_params(1, ResponseCode::GeneralError, &[]));
+        mock.queue_response(response_with_params(0, ResponseCode::GeneralError, &[]));
 
         let result = PtpSession::open(transport, 1).await;
         assert!(result.is_err());
@@ -473,13 +472,13 @@ mod tests {
     #[tokio::test]
     async fn test_transaction_id_increment() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // First operation
-        mock.queue_response(ok_response(3)); // Second operation
+        mock.queue_response(ok_response(0)); // OpenSession (session-less, tx_id=0)
+        mock.queue_response(ok_response(1)); // First operation
+        mock.queue_response(ok_response(2)); // Second operation
 
         let session = PtpSession::open(transport, 1).await.unwrap();
 
-        // Execute two operations and verify transaction IDs increment
+        // First post-open operation uses tx_id=1, second uses tx_id=2
         session.delete_object(ObjectHandle(1)).await.unwrap();
         session.delete_object(ObjectHandle(2)).await.unwrap();
     }
@@ -487,7 +486,7 @@ mod tests {
     #[tokio::test]
     async fn test_transaction_id_mismatch() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession (session-less, tx_id=0)
         mock.queue_response(ok_response(999)); // Wrong transaction ID
 
         let session = PtpSession::open(transport, 1).await.unwrap();
@@ -499,8 +498,8 @@ mod tests {
     #[tokio::test]
     async fn test_close_session() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // CloseSession
+        mock.queue_response(ok_response(0)); // OpenSession (session-less, tx_id=0)
+        mock.queue_response(ok_response(1)); // CloseSession (tx_id=1)
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session.close().await.unwrap();
@@ -509,8 +508,8 @@ mod tests {
     #[tokio::test]
     async fn test_close_session_ignores_errors() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(response_with_params(2, ResponseCode::GeneralError, &[])); // CloseSession error
+        mock.queue_response(ok_response(0)); // OpenSession (session-less, tx_id=0)
+        mock.queue_response(response_with_params(1, ResponseCode::GeneralError, &[])); // CloseSession error (tx_id=1)
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         // Should succeed even if close fails

--- a/src/ptp/session/operations.rs
+++ b/src/ptp/session/operations.rs
@@ -412,16 +412,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_storage_ids() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // GetStorageIds data response
         let storage_ids_data = pack_u32_array(&[0x00010001, 0x00010002]);
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetStorageIds,
             &storage_ids_data,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let ids = session.get_storage_ids().await.unwrap();
@@ -432,16 +432,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_object_handles() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // GetObjectHandles data response
         let handles_data = pack_u32_array(&[1, 2, 3]);
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetObjectHandles,
             &handles_data,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let handles = session
@@ -458,12 +458,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_object() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // GetObject data response
         let object_data = vec![0x01, 0x02, 0x03, 0x04, 0x05];
-        mock.queue_response(data_container(2, OperationCode::GetObject, &object_data));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(data_container(1, OperationCode::GetObject, &object_data));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let data = session.get_object(ObjectHandle(1)).await.unwrap();
@@ -474,8 +474,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_object() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // DeleteObject
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // DeleteObject
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session.delete_object(ObjectHandle(1)).await.unwrap();
@@ -484,8 +484,8 @@ mod tests {
     #[tokio::test]
     async fn test_copy_object() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(response_with_params(2, ResponseCode::Ok, &[100])); // CopyObject with new handle
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(response_with_params(1, ResponseCode::Ok, &[100])); // CopyObject with new handle
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let new_handle = session
@@ -503,7 +503,7 @@ mod tests {
         use crate::ptp::EventCode;
 
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue an ObjectAdded event (code 0x4002)
         mock.queue_interrupt(event_container(0x4002, [42, 0, 0]));
@@ -520,7 +520,7 @@ mod tests {
         use crate::ptp::EventCode;
 
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue a StoreRemoved event (code 0x4005)
         mock.queue_interrupt(event_container(0x4005, [0x00010001, 0, 0]));
@@ -537,7 +537,7 @@ mod tests {
         use crate::ptp::EventCode;
 
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue multiple events
         mock.queue_interrupt(event_container(0x4002, [1, 0, 0])); // ObjectAdded
@@ -564,16 +564,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_object_prop_value() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // GetObjectPropValue data response (property value is raw bytes)
         let prop_value = vec![0x05, 0x48, 0x00, 0x69, 0x00, 0x00, 0x00]; // Packed string "Hi"
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetObjectPropValue,
             &prop_value,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let data = session
@@ -587,8 +587,8 @@ mod tests {
     #[tokio::test]
     async fn test_set_object_prop_value() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SetObjectPropValue
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SetObjectPropValue
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let prop_value = pack_string("newfile.txt");
@@ -605,9 +605,9 @@ mod tests {
     #[tokio::test]
     async fn test_set_object_prop_value_not_supported() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
         mock.queue_response(response_with_params(
-            2,
+            1,
             ResponseCode::OperationNotSupported,
             &[],
         ));
@@ -634,8 +634,8 @@ mod tests {
     #[tokio::test]
     async fn test_rename_object() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SetObjectPropValue (for rename)
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SetObjectPropValue (for rename)
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session
@@ -647,9 +647,9 @@ mod tests {
     #[tokio::test]
     async fn test_rename_object_not_supported() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
         mock.queue_response(response_with_params(
-            2,
+            1,
             ResponseCode::OperationNotSupported,
             &[],
         ));
@@ -671,8 +671,8 @@ mod tests {
     #[tokio::test]
     async fn test_initiate_capture() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // InitiateCapture
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // InitiateCapture
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session
@@ -684,8 +684,8 @@ mod tests {
     #[tokio::test]
     async fn test_initiate_capture_with_format() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // InitiateCapture
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // InitiateCapture
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session
@@ -697,9 +697,9 @@ mod tests {
     #[tokio::test]
     async fn test_initiate_capture_not_supported() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
         mock.queue_response(response_with_params(
-            2,
+            1,
             ResponseCode::OperationNotSupported,
             &[],
         ));

--- a/src/ptp/session/properties.rs
+++ b/src/ptp/session/properties.rs
@@ -182,16 +182,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_device_prop_desc() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue battery level prop desc
         let prop_desc_data = build_battery_prop_desc(75);
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetDevicePropDesc,
             &prop_desc_data,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let desc = session
@@ -208,9 +208,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_device_prop_desc_not_supported() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
         mock.queue_response(response_with_params(
-            2,
+            1,
             ResponseCode::DevicePropNotSupported,
             &[],
         ));
@@ -232,16 +232,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_device_prop_value() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue battery level value (75%)
         let value_data = vec![75u8];
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetDevicePropValue,
             &value_data,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let data = session
@@ -255,16 +255,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_device_prop_value_typed() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Queue ISO value (400 = 0x0190)
         let value_data = vec![0x90, 0x01]; // 400 in little-endian
         mock.queue_response(data_container(
-            2,
+            1,
             OperationCode::GetDevicePropValue,
             &value_data,
         ));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(ok_response(1));
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let value = session
@@ -281,8 +281,8 @@ mod tests {
     #[tokio::test]
     async fn test_set_device_prop_value() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SetDevicePropValue
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SetDevicePropValue
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         let value = vec![0x90, 0x01]; // 400 in little-endian
@@ -295,8 +295,8 @@ mod tests {
     #[tokio::test]
     async fn test_set_device_prop_value_typed() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SetDevicePropValue
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SetDevicePropValue
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session
@@ -311,9 +311,9 @@ mod tests {
     #[tokio::test]
     async fn test_set_device_prop_value_invalid() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
         mock.queue_response(response_with_params(
-            2,
+            1,
             ResponseCode::InvalidDevicePropValue,
             &[],
         ));
@@ -335,8 +335,8 @@ mod tests {
     #[tokio::test]
     async fn test_reset_device_prop_value() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // ResetDevicePropValue
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // ResetDevicePropValue
 
         let session = PtpSession::open(transport, 1).await.unwrap();
         session

--- a/src/ptp/session/streaming.rs
+++ b/src/ptp/session/streaming.rs
@@ -374,12 +374,12 @@ mod tests {
     #[tokio::test]
     async fn test_receive_stream_small_file() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // GetObject data response (small file fits in one container)
         let file_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        mock.queue_response(data_container(2, OperationCode::GetObject, &file_data));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(data_container(1, OperationCode::GetObject, &file_data));
+        mock.queue_response(ok_response(1));
 
         let session = Arc::new(PtpSession::open(transport, 1).await.unwrap());
 
@@ -399,11 +399,11 @@ mod tests {
     #[tokio::test]
     async fn test_receive_stream_collect() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         let file_data = vec![1, 2, 3, 4, 5];
-        mock.queue_response(data_container(2, OperationCode::GetObject, &file_data));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(data_container(1, OperationCode::GetObject, &file_data));
+        mock.queue_response(ok_response(1));
 
         let session = Arc::new(PtpSession::open(transport, 1).await.unwrap());
 
@@ -416,7 +416,7 @@ mod tests {
     #[tokio::test]
     async fn test_receive_stream_error_response() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         // Return error response instead of data
         mock.queue_response(response_with_params(
@@ -441,8 +441,8 @@ mod tests {
         use futures::stream;
 
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SendObject response
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SendObject response
 
         let session = PtpSession::open(transport, 1).await.unwrap();
 
@@ -459,8 +459,8 @@ mod tests {
         use futures::stream;
 
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
-        mock.queue_response(ok_response(2)); // SendObject response
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // SendObject response
 
         let session = PtpSession::open(transport, 1).await.unwrap();
 
@@ -479,11 +479,11 @@ mod tests {
     #[tokio::test]
     async fn test_receive_stream_to_stream_conversion() {
         let (transport, mock) = mock_transport();
-        mock.queue_response(ok_response(1)); // OpenSession
+        mock.queue_response(ok_response(0)); // OpenSession
 
         let file_data = vec![1, 2, 3, 4, 5];
-        mock.queue_response(data_container(2, OperationCode::GetObject, &file_data));
-        mock.queue_response(ok_response(2));
+        mock.queue_response(data_container(1, OperationCode::GetObject, &file_data));
+        mock.queue_response(ok_response(1));
 
         let session = Arc::new(PtpSession::open(transport, 1).await.unwrap());
 


### PR DESCRIPTION
OpenSession is a session-less PTP operation and should therefore be sent with
`transaction_id = 0`.

The current implementation routes OpenSession through the general `execute()`
path, which assigns the first in-session transaction id instead. That makes the
transaction sequence start one step too early.

This patch extracts OpenSession into a dedicated `send_open_session()` helper
and sends it with `TransactionId::SESSION_LESS` (`0`), while leaving the first
session-bound operation at `TransactionId::FIRST` (`1`).

This is a protocol-correctness fix rather than a vendor-specific quirk.
It also resolves interoperability with Kindle devices, which appear to enforce
this part of the PTP behavior more strictly and reject `OpenSession` with a
non-zero transaction id.

I would not expect this to affect Android devices, since it only makes
OpenSession spec-correct and does not introduce any device-specific behavior.

The accompanying tests are updated to reflect the corrected transaction-id
sequence.