### PR TITLE
Add low-level primitives for non-standard MTP devices

### DIFF
--- a/src/mtp/device.rs
+++ b/src/mtp/device.rs
@@ -89,7 +89,33 @@ impl MtpDevice {
 
     /// List all available MTP devices without opening them.
     pub fn list_devices() -> Result<Vec<MtpDeviceInfo>, Error> {
-        let devices = NusbTransport::list_mtp_devices()?;
+        Self::list_devices_with_known(&[])
+    }
+
+    /// List all available MTP devices, including additional devices identified
+    /// by the given VID/PID pairs.
+    ///
+    /// Devices matching the provided VID/PID pairs are included in the results
+    /// even if their USB descriptors don't match standard MTP class codes. This
+    /// is useful for legacy or otherwise unusual devices with non-standard USB
+    /// descriptors that still speak MTP.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mtp_rs::mtp::MtpDevice;
+    ///
+    /// let devices = MtpDevice::list_devices_with_known(&[
+    ///     (0x045E, 0x0710), // custom VID/PID
+    /// ])?;
+    /// for d in &devices {
+    ///     println!("{:04x}:{:04x} {}", d.vendor_id, d.product_id,
+    ///              d.product.as_deref().unwrap_or("unknown"));
+    /// }
+    /// # Ok::<(), mtp_rs::Error>(())
+    /// ```
+    pub fn list_devices_with_known(known: &[(u16, u16)]) -> Result<Vec<MtpDeviceInfo>, Error> {
+        let devices = NusbTransport::list_mtp_devices_with_known(known)?;
         #[allow(unused_mut)]
         let mut result: Vec<MtpDeviceInfo> = devices
             .into_iter()
@@ -113,6 +139,19 @@ impl MtpDevice {
     #[must_use]
     pub fn device_info(&self) -> &DeviceInfo {
         &self.inner.device_info
+    }
+
+    /// Get a reference to the underlying [`PtpSession`].
+    ///
+    /// Provides direct access to low-level PTP operations
+    /// ([`execute`](PtpSession::execute),
+    /// [`execute_with_send`](PtpSession::execute_with_send),
+    /// [`execute_with_receive`](PtpSession::execute_with_receive))
+    /// and per-device knobs like
+    /// [`set_split_header_data`](PtpSession::set_split_header_data).
+    #[must_use]
+    pub fn session(&self) -> &PtpSession {
+        &self.inner.session
     }
 
     /// Check if the device supports renaming objects.
@@ -338,6 +377,7 @@ impl MtpDeviceInfo {
 /// Builder for MtpDevice configuration.
 pub struct MtpDeviceBuilder {
     timeout: Duration,
+    known_devices: Vec<(u16, u16)>,
 }
 
 impl MtpDeviceBuilder {
@@ -345,6 +385,7 @@ impl MtpDeviceBuilder {
     pub fn new() -> Self {
         Self {
             timeout: NusbTransport::DEFAULT_TIMEOUT,
+            known_devices: Vec::new(),
         }
     }
 
@@ -358,12 +399,53 @@ impl MtpDeviceBuilder {
         self
     }
 
+    /// Include additional devices identified by VID/PID pairs in the open-time
+    /// device scan.
+    ///
+    /// By default, the `open_first` / `open_by_serial` / `open_by_location`
+    /// convenience methods only consider devices whose USB descriptors match
+    /// standard MTP class codes. Pass extra VID/PID pairs here to also accept
+    /// legacy or otherwise unusual devices that speak MTP despite reporting
+    /// non-standard descriptors.
+    ///
+    /// This is the open-side counterpart to [`MtpDevice::list_devices_with_known`]:
+    /// pair them with the same list to enumerate and open the same set of devices.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mtp_rs::mtp::MtpDevice;
+    ///
+    /// # async fn example() -> Result<(), mtp_rs::Error> {
+    /// let known = &[(0x045E, 0x0710)];
+    ///
+    /// // Enumerate with the extra VID/PID...
+    /// let devices = MtpDevice::list_devices_with_known(known)?;
+    /// let info = devices.into_iter().next().ok_or(mtp_rs::Error::NoDevice)?;
+    ///
+    /// // ...and open with the same list so the builder can find the device.
+    /// let device = MtpDevice::builder()
+    ///     .known_devices(known)
+    ///     .open_by_location(info.location_id)
+    ///     .await?;
+    ///
+    /// // Apply any per-device knobs after opening.
+    /// device.session().set_split_header_data(true);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn known_devices(mut self, known: &[(u16, u16)]) -> Self {
+        self.known_devices = known.to_vec();
+        self
+    }
+
     /// Open the first available device.
     pub async fn open_first(self) -> Result<MtpDevice, Error> {
-        let devices = NusbTransport::list_mtp_devices()?;
+        let devices = NusbTransport::list_mtp_devices_with_known(&self.known_devices)?;
         let device_info = devices.into_iter().next().ok_or(Error::NoDevice)?;
         let device = device_info.open().map_err(Error::Usb)?;
-        self.open_device(device).await
+        self.open_nusb_device(device).await
     }
 
     /// Open a device at a specific USB location (port).
@@ -378,13 +460,13 @@ impl MtpDeviceBuilder {
             return self.open_virtual(config).await;
         }
 
-        let devices = NusbTransport::list_mtp_devices()?;
+        let devices = NusbTransport::list_mtp_devices_with_known(&self.known_devices)?;
         let device_info = devices
             .into_iter()
             .find(|d| d.location_id == location_id)
             .ok_or(Error::NoDevice)?;
         let device = device_info.open().map_err(Error::Usb)?;
-        self.open_device(device).await
+        self.open_nusb_device(device).await
     }
 
     /// Open a device by its serial number.
@@ -400,18 +482,50 @@ impl MtpDeviceBuilder {
             return self.open_virtual(config).await;
         }
 
-        let devices = NusbTransport::list_mtp_devices()?;
+        let devices = NusbTransport::list_mtp_devices_with_known(&self.known_devices)?;
         let device_info = devices
             .into_iter()
             .find(|d| d.serial_number.as_deref() == Some(serial))
             .ok_or(Error::NoDevice)?;
         let device = device_info.open().map_err(Error::Usb)?;
-        self.open_device(device).await
+        self.open_nusb_device(device).await
     }
 
-    /// Internal: open an already-discovered device.
-    async fn open_device(self, device: nusb::Device) -> Result<MtpDevice, Error> {
-        // Open transport
+    /// Open an already-acquired [`nusb::Device`] as an MTP device.
+    ///
+    /// This is an escape hatch for consumers who already hold an `nusb::Device`
+    /// (e.g. from a custom enumeration or hotplug watcher). For most callers,
+    /// prefer [`known_devices`](Self::known_devices) combined with
+    /// `open_by_serial` / `open_by_location`.
+    ///
+    /// The interface scan is permissive: strict MTP-class match first, then
+    /// fallback to any interface with the MTP endpoint layout. Per-device knobs
+    /// like [`PtpSession::set_split_header_data`] can be applied after opening
+    /// via [`MtpDevice::session()`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mtp_rs::mtp::MtpDevice;
+    /// use nusb::MaybeFuture;
+    ///
+    /// # async fn example() -> Result<(), mtp_rs::Error> {
+    /// let nusb_device = nusb::list_devices()
+    ///     .wait()?
+    ///     .find(|d: &nusb::DeviceInfo| {
+    ///         d.vendor_id() == 0x045E && d.product_id() == 0x0710
+    ///     })
+    ///     .ok_or(mtp_rs::Error::NoDevice)?
+    ///     .open()
+    ///     .wait()?;
+    ///
+    /// let device = MtpDevice::builder()
+    ///     .open_nusb_device(nusb_device)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn open_nusb_device(self, device: nusb::Device) -> Result<MtpDevice, Error> {
         let transport = NusbTransport::open_with_timeout(device, self.timeout).await?;
         let transport: Arc<dyn Transport> = Arc::new(transport);
 

--- a/src/ptp/session/mod.rs
+++ b/src/ptp/session/mod.rs
@@ -10,13 +10,13 @@ mod streaming;
 pub use streaming::{receive_stream_to_stream, ReceiveStream};
 
 use crate::ptp::{
-    container_type, unpack_u32, CommandContainer, ContainerType, DataContainer, OperationCode,
-    ResponseCode, ResponseContainer, SessionId, TransactionId,
+    container_type, pack_u16, pack_u32, unpack_u32, CommandContainer, ContainerType, DataContainer,
+    OperationCode, ResponseCode, ResponseContainer, SessionId, TransactionId,
 };
 use crate::transport::Transport;
 use crate::Error;
 use futures::lock::Mutex;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// Container header size in bytes.
@@ -60,6 +60,10 @@ pub struct PtpSession {
     /// Mutex to serialize operations (MTP only allows one operation at a time).
     /// Wrapped in Arc so it can be shared with ReceiveStream.
     pub(crate) operation_lock: Arc<Mutex<()>>,
+    /// Whether to send data container headers separately from payloads.
+    /// Some devices require the 12-byte PTP header and data payload to arrive
+    /// as separate USB bulk transfers.
+    split_header_data: AtomicBool,
 }
 
 impl PtpSession {
@@ -70,7 +74,24 @@ impl PtpSession {
             session_id,
             transaction_id: AtomicU32::new(TransactionId::FIRST.0),
             operation_lock: Arc::new(Mutex::new(())),
+            split_header_data: AtomicBool::new(false),
         }
+    }
+
+    /// Enable or disable split header/data mode for sending data containers.
+    ///
+    /// When enabled, the 12-byte PTP container header and payload are sent as
+    /// separate USB bulk transfers in [`execute_with_send`](Self::execute_with_send).
+    /// Required by some devices that don't handle a combined header+data
+    /// bulk transfer.
+    pub fn set_split_header_data(&self, split: bool) {
+        self.split_header_data.store(split, Ordering::Relaxed);
+    }
+
+    /// Whether split header/data mode is currently enabled.
+    #[must_use]
+    pub fn is_split_header_data(&self) -> bool {
+        self.split_header_data.load(Ordering::Relaxed)
     }
 
     /// Open a new session with the device.
@@ -177,8 +198,12 @@ impl PtpSession {
     // Core operation execution
     // =========================================================================
 
-    /// Execute an operation without data phase.
-    pub(crate) async fn execute(
+    /// Execute a PTP operation without a data phase.
+    ///
+    /// Exposed for vendor-specific or otherwise non-standard PTP operations
+    /// that aren't covered by the high-level API. Access via
+    /// [`MtpDevice::session()`](crate::mtp::MtpDevice::session).
+    pub async fn execute(
         &self,
         operation: OperationCode,
         params: &[u32],
@@ -210,8 +235,32 @@ impl PtpSession {
         Ok(response)
     }
 
-    /// Execute operation with data receive phase.
-    pub(crate) async fn execute_with_receive(
+    /// Execute a PTP operation with a data receive phase.
+    ///
+    /// Returns the response container along with the received data payload.
+    /// Useful for vendor-specific operations that return data.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mtp_rs::mtp::MtpDevice;
+    /// use mtp_rs::ptp::{OperationCode, ResponseCode};
+    ///
+    /// # async fn example() -> Result<(), mtp_rs::Error> {
+    /// let device = MtpDevice::open_first().await?;
+    ///
+    /// // Execute a vendor-specific operation (0x9501)
+    /// let (response, data) = device.session()
+    ///     .execute_with_receive(OperationCode::Unknown(0x9501), &[])
+    ///     .await?;
+    ///
+    /// if response.code == ResponseCode::Ok {
+    ///     println!("received {} bytes", data.len());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn execute_with_receive(
         &self,
         operation: OperationCode,
         params: &[u32],
@@ -281,8 +330,15 @@ impl PtpSession {
         }
     }
 
-    /// Execute operation with data send phase.
-    pub(crate) async fn execute_with_send(
+    /// Execute a PTP operation with a data send phase.
+    ///
+    /// Sends the provided payload to the device as part of the operation.
+    /// Useful for vendor-specific operations that require sending data.
+    ///
+    /// When [`is_split_header_data`](Self::is_split_header_data) is enabled, the
+    /// 12-byte PTP container header and the payload are sent as separate USB
+    /// bulk transfers.
+    pub async fn execute_with_send(
         &self,
         operation: OperationCode,
         params: &[u32],
@@ -300,13 +356,28 @@ impl PtpSession {
         };
         self.transport.send_bulk(&cmd.to_bytes()).await?;
 
-        // Send data
-        let data_container = DataContainer {
-            code: operation,
-            transaction_id: tx_id,
-            payload: data.to_vec(),
-        };
-        self.transport.send_bulk(&data_container.to_bytes()).await?;
+        // Send data container
+        if self.split_header_data.load(Ordering::Relaxed) {
+            // Split mode: send the 12-byte header and the payload as two
+            // separate USB bulk transfers. Required by some devices.
+            let total_len = (HEADER_SIZE + data.len()) as u32;
+            let mut header = Vec::with_capacity(HEADER_SIZE);
+            header.extend_from_slice(&pack_u32(total_len));
+            header.extend_from_slice(&pack_u16(ContainerType::Data.to_code()));
+            header.extend_from_slice(&pack_u16(operation.into()));
+            header.extend_from_slice(&pack_u32(tx_id));
+            self.transport.send_bulk(&header).await?;
+            if !data.is_empty() {
+                self.transport.send_bulk(data).await?;
+            }
+        } else {
+            let data_container = DataContainer {
+                code: operation,
+                transaction_id: tx_id,
+                payload: data.to_vec(),
+            };
+            self.transport.send_bulk(&data_container.to_bytes()).await?;
+        }
 
         // Receive response
         let response_bytes = self.transport.receive_bulk(512).await?;
@@ -496,6 +567,215 @@ mod tests {
         let result = session.delete_object(ObjectHandle(1)).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_combined_default() {
+        // By default, command + combined data container = 2 bulk sends.
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // operation response
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        assert!(!session.is_split_header_data());
+
+        let payload = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        session
+            .execute_with_send(OperationCode::SendObject, &[], &payload)
+            .await
+            .unwrap();
+
+        // 1 send for OpenSession command + 2 here = 3 total.
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 3);
+
+        // Third send is the combined data container: 12-byte header + 4-byte payload.
+        let data = &sends[2];
+        assert_eq!(data.len(), HEADER_SIZE + payload.len());
+        assert_eq!(unpack_u32(&data[0..4]).unwrap() as usize, data.len());
+        assert_eq!(&data[HEADER_SIZE..], payload.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_split_header_data() {
+        // With split mode enabled, header and payload are sent as 2 separate transfers.
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // operation response
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        session.set_split_header_data(true);
+        assert!(session.is_split_header_data());
+
+        let payload = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        session
+            .execute_with_send(OperationCode::SendObject, &[], &payload)
+            .await
+            .unwrap();
+
+        // OpenSession (1) + command (1) + header (1) + payload (1) = 4 sends.
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 4);
+
+        // Third send is the bare 12-byte header reporting the full container length.
+        let header = &sends[2];
+        assert_eq!(header.len(), HEADER_SIZE);
+        assert_eq!(
+            unpack_u32(&header[0..4]).unwrap() as usize,
+            HEADER_SIZE + payload.len()
+        );
+
+        // Fourth send is the raw payload, no extra framing.
+        assert_eq!(sends[3], payload);
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_split_empty_payload() {
+        // With split mode and an empty payload, only the header is sent (no second transfer).
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(ok_response(1));
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        session.set_split_header_data(true);
+
+        session
+            .execute_with_send(OperationCode::SendObject, &[], &[])
+            .await
+            .unwrap();
+
+        // OpenSession + command + header only = 3.
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 3);
+        assert_eq!(sends[2].len(), HEADER_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_stream_combined_default() {
+        // By default, command + combined data container = 2 bulk sends, regardless
+        // of how many chunks the input stream is split into.
+        use bytes::Bytes;
+        use futures::stream;
+
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // operation response
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        assert!(!session.is_split_header_data());
+
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![
+            Ok(Bytes::from_static(&[0xAA, 0xBB])),
+            Ok(Bytes::from_static(&[0xCC, 0xDD])),
+        ];
+        let total_size = 4u64;
+
+        session
+            .execute_with_send_stream(
+                OperationCode::SendObject,
+                &[],
+                total_size,
+                stream::iter(chunks),
+            )
+            .await
+            .unwrap();
+
+        // OpenSession (1) + command (1) + combined data container (1) = 3 sends.
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 3);
+
+        // Third send is the combined data container.
+        let data = &sends[2];
+        assert_eq!(data.len(), HEADER_SIZE + total_size as usize);
+        assert_eq!(unpack_u32(&data[0..4]).unwrap() as usize, data.len());
+        assert_eq!(&data[HEADER_SIZE..], &[0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_stream_split_header_data() {
+        // With split mode enabled, the header is sent first as its own bulk
+        // transfer and then each non-empty chunk is sent as its own transfer.
+        use bytes::Bytes;
+        use futures::stream;
+
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0)); // OpenSession
+        mock.queue_response(ok_response(1)); // operation response
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        session.set_split_header_data(true);
+
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![
+            Ok(Bytes::from_static(&[0xAA, 0xBB])),
+            Ok(Bytes::from_static(&[0xCC, 0xDD])),
+        ];
+        let total_size = 4u64;
+
+        session
+            .execute_with_send_stream(
+                OperationCode::SendObject,
+                &[],
+                total_size,
+                stream::iter(chunks),
+            )
+            .await
+            .unwrap();
+
+        // OpenSession (1) + command (1) + header (1) + chunk1 (1) + chunk2 (1) = 5.
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 5);
+
+        // Third send is the bare 12-byte header reporting the full container length.
+        let header = &sends[2];
+        assert_eq!(header.len(), HEADER_SIZE);
+        assert_eq!(
+            unpack_u32(&header[0..4]).unwrap() as usize,
+            HEADER_SIZE + total_size as usize
+        );
+
+        // Fourth and fifth sends are the raw chunks, no extra framing.
+        assert_eq!(sends[3], &[0xAA, 0xBB]);
+        assert_eq!(sends[4], &[0xCC, 0xDD]);
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_send_stream_split_skips_empty_chunks() {
+        // Empty chunks in split mode must not be sent as zero-length bulk
+        // transfers (which some devices treat as end-of-transfer markers).
+        use bytes::Bytes;
+        use futures::stream;
+
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(ok_response(1));
+
+        let session = PtpSession::open(transport, 1).await.unwrap();
+        session.set_split_header_data(true);
+
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![
+            Ok(Bytes::from_static(&[0xAA])),
+            Ok(Bytes::new()), // empty — should be skipped
+            Ok(Bytes::from_static(&[0xBB])),
+        ];
+        let total_size = 2u64;
+
+        session
+            .execute_with_send_stream(
+                OperationCode::SendObject,
+                &[],
+                total_size,
+                stream::iter(chunks),
+            )
+            .await
+            .unwrap();
+
+        // OpenSession + command + header + chunk1 + chunk3 = 5 (the empty
+        // chunk in the middle must not produce a send).
+        let sends = mock.get_sends();
+        assert_eq!(sends.len(), 5);
+        assert_eq!(sends[2].len(), HEADER_SIZE);
+        assert_eq!(sends[3], &[0xAA]);
+        assert_eq!(sends[4], &[0xBB]);
     }
 
     #[tokio::test]

--- a/src/ptp/session/streaming.rs
+++ b/src/ptp/session/streaming.rs
@@ -88,6 +88,11 @@ impl PtpSession {
     ///
     /// The `total_size` must match the actual total bytes in the stream.
     /// MTP requires knowing the size before transfer begins.
+    ///
+    /// When [`is_split_header_data`](Self::is_split_header_data) is enabled, the
+    /// 12-byte PTP container header and the streamed payload are sent as
+    /// separate USB bulk transfers, mirroring the behavior of
+    /// [`execute_with_send`](Self::execute_with_send).
     pub async fn execute_with_send_stream<S>(
         &self,
         operation: OperationCode,
@@ -99,6 +104,7 @@ impl PtpSession {
         S: Stream<Item = Result<Bytes, std::io::Error>> + Unpin,
     {
         use futures::StreamExt;
+        use std::sync::atomic::Ordering;
 
         let _guard = self.operation_lock.lock().await;
         let tx_id = self.next_transaction_id();
@@ -111,29 +117,42 @@ impl PtpSession {
         };
         self.transport.send_bulk(&cmd.to_bytes()).await?;
 
-        // Build complete data container (header + all payload)
-        // MTP devices expect the entire data container in a single USB transfer
         let container_length = HEADER_SIZE as u64 + total_size;
-        let mut buffer = Vec::with_capacity(container_length as usize);
 
-        // Add header
+        // Build the 12-byte data container header.
+        let mut header = Vec::with_capacity(HEADER_SIZE);
         if container_length <= u32::MAX as u64 {
-            buffer.extend_from_slice(&pack_u32(container_length as u32));
+            header.extend_from_slice(&pack_u32(container_length as u32));
         } else {
-            buffer.extend_from_slice(&pack_u32(0xFFFFFFFF));
+            header.extend_from_slice(&pack_u32(0xFFFFFFFF));
         }
-        buffer.extend_from_slice(&pack_u16(ContainerType::Data.to_code()));
-        buffer.extend_from_slice(&pack_u16(operation.into()));
-        buffer.extend_from_slice(&pack_u32(tx_id));
+        header.extend_from_slice(&pack_u16(ContainerType::Data.to_code()));
+        header.extend_from_slice(&pack_u16(operation.into()));
+        header.extend_from_slice(&pack_u32(tx_id));
 
-        // Collect all chunks into buffer
-        while let Some(chunk_result) = data.next().await {
-            let chunk = chunk_result.map_err(Error::Io)?;
-            buffer.extend_from_slice(&chunk);
+        if self.split_header_data.load(Ordering::Relaxed) {
+            // Split mode: send the header as its own bulk transfer, then send
+            // each streamed chunk as its own bulk transfer. Required by some
+            // devices that don't handle a combined header+data bulk transfer.
+            self.transport.send_bulk(&header).await?;
+            while let Some(chunk_result) = data.next().await {
+                let chunk = chunk_result.map_err(Error::Io)?;
+                if !chunk.is_empty() {
+                    self.transport.send_bulk(&chunk).await?;
+                }
+            }
+        } else {
+            // Combined mode: collect header + all chunks into one buffer and
+            // send as a single USB transfer. This is the default and what most
+            // devices expect.
+            let mut buffer = Vec::with_capacity(container_length as usize);
+            buffer.extend_from_slice(&header);
+            while let Some(chunk_result) = data.next().await {
+                let chunk = chunk_result.map_err(Error::Io)?;
+                buffer.extend_from_slice(&chunk);
+            }
+            self.transport.send_bulk(&buffer).await?;
         }
-
-        // Send entire data container as one USB transfer
-        self.transport.send_bulk(&buffer).await?;
 
         // Receive response
         let response_bytes = self.transport.receive_bulk(512).await?;

--- a/src/transport/nusb.rs
+++ b/src/transport/nusb.rs
@@ -62,10 +62,21 @@ impl NusbTransport {
 
     /// List all available MTP devices with location IDs.
     pub fn list_mtp_devices() -> Result<Vec<UsbDeviceInfo>, crate::Error> {
+        Self::list_mtp_devices_with_known(&[])
+    }
+
+    /// List all available MTP devices, including additional devices identified
+    /// by the given VID/PID pairs.
+    ///
+    /// Devices matching the provided VID/PID pairs are included in the results
+    /// even if their USB descriptors don't match standard MTP class codes.
+    pub fn list_mtp_devices_with_known(
+        known: &[(u16, u16)],
+    ) -> Result<Vec<UsbDeviceInfo>, crate::Error> {
         let devices = nusb::list_devices()
             .wait()
             .map_err(crate::Error::Usb)?
-            .filter(Self::is_mtp_device)
+            .filter(|dev| Self::is_mtp_device(dev, known))
             .map(|dev| {
                 let location_id = location_id_from_topology(&dev);
                 UsbDeviceInfo {
@@ -83,7 +94,20 @@ impl NusbTransport {
     }
 
     /// Check if a device info represents an MTP device.
-    fn is_mtp_device(dev: &nusb::DeviceInfo) -> bool {
+    ///
+    /// A device is considered MTP if it matches standard MTP class codes, has
+    /// an interface with the MTP endpoint layout, or matches one of the
+    /// caller-provided VID/PID pairs (used for devices with non-standard USB
+    /// descriptors that still speak MTP).
+    fn is_mtp_device(dev: &nusb::DeviceInfo, known: &[(u16, u16)]) -> bool {
+        // Fast path: caller-supplied known devices that may use non-standard descriptors.
+        if known
+            .iter()
+            .any(|&(v, p)| v == dev.vendor_id() && p == dev.product_id())
+        {
+            return true;
+        }
+
         // Check device class/subclass/protocol at device level.
         if Self::is_mtp_class(dev.class(), dev.subclass(), dev.protocol()) {
             return true;
@@ -159,12 +183,32 @@ impl NusbTransport {
         bulk_in && bulk_out && interrupt_in
     }
 
+    /// Whether a `claim_interface` failure looks like the OS hasn't published
+    /// the interface yet (rather than a permanent error).
+    ///
+    /// On macOS, vendor-class or class-0 devices that IOKit doesn't
+    /// auto-configure end up with no `IOUSBHostInterface` services published,
+    /// even when the device's configuration descriptor reports otherwise.
+    /// The resulting `claim_interface` error is `NotFound` — there's nothing
+    /// for nusb to claim — and the fix is to issue `SetConfiguration(1)`,
+    /// which makes IOKit publish the interface objects.
+    fn is_interface_unpublished(e: &nusb::Error) -> bool {
+        matches!(e.kind(), nusb::ErrorKind::NotFound)
+    }
+
     /// Open a specific device and claim the MTP interface.
     pub async fn open(device: nusb::Device) -> Result<Self, crate::Error> {
         Self::open_with_timeout(device, Self::DEFAULT_TIMEOUT).await
     }
 
     /// Open with custom bulk transfer timeout.
+    ///
+    /// The interface scan first looks for a strict MTP-class interface; if none
+    /// is found, it falls back to any interface with the MTP endpoint layout
+    /// (bulk IN + bulk OUT + interrupt IN). This relaxed fallback supports
+    /// legacy devices that report a non-standard interface class — the caller
+    /// has already hand-picked the device, so the scan can be permissive at
+    /// this point.
     pub async fn open_with_timeout(
         device: nusb::Device,
         timeout: Duration,
@@ -179,34 +223,45 @@ impl NusbTransport {
         let mut bulk_out_addr = None;
         let mut interrupt_in_addr = None;
 
-        for interface in config.interfaces() {
-            // Get the first alternate setting for this interface
-            let Some(alt_setting) = interface.alt_settings().next() else {
-                continue;
-            };
-
-            // Check if this interface is MTP (standard or vendor-specific with MTP endpoints)
-            if Self::is_mtp_interface(&alt_setting) {
-                mtp_interface_number = Some(interface.interface_number());
-
-                // Find endpoints
-                for endpoint in alt_setting.endpoints() {
-                    match (endpoint.direction(), endpoint.transfer_type()) {
-                        (Direction::Out, TransferType::Bulk) => {
-                            bulk_out_addr = Some(endpoint.address());
+        // Two-pass scan: prefer a strictly-matching MTP interface, but fall
+        // back to any interface with the MTP endpoint layout. The caller has
+        // already hand-picked the device, so a permissive fallback is safe and
+        // supports legacy devices that report a non-standard interface class.
+        let pick = |strict: bool| {
+            for interface in config.interfaces() {
+                let Some(alt_setting) = interface.alt_settings().next() else {
+                    continue;
+                };
+                let matches = if strict {
+                    Self::is_mtp_interface(&alt_setting)
+                } else {
+                    Self::has_mtp_endpoint_layout(&alt_setting)
+                };
+                if matches {
+                    let mut bin = None;
+                    let mut bout = None;
+                    let mut iin = None;
+                    for endpoint in alt_setting.endpoints() {
+                        match (endpoint.direction(), endpoint.transfer_type()) {
+                            (Direction::Out, TransferType::Bulk) => bout = Some(endpoint.address()),
+                            (Direction::In, TransferType::Bulk) => bin = Some(endpoint.address()),
+                            (Direction::In, TransferType::Interrupt) => {
+                                iin = Some(endpoint.address())
+                            }
+                            _ => {}
                         }
-                        (Direction::In, TransferType::Bulk) => {
-                            bulk_in_addr = Some(endpoint.address());
-                        }
-                        (Direction::In, TransferType::Interrupt) => {
-                            interrupt_in_addr = Some(endpoint.address());
-                        }
-                        _ => {}
                     }
+                    return Some((interface.interface_number(), bin, bout, iin));
                 }
-
-                break;
             }
+            None
+        };
+
+        if let Some((n, bin, bout, iin)) = pick(true).or_else(|| pick(false)) {
+            mtp_interface_number = Some(n);
+            bulk_in_addr = bin;
+            bulk_out_addr = bout;
+            interrupt_in_addr = iin;
         }
 
         let interface_number = mtp_interface_number
@@ -220,10 +275,25 @@ impl NusbTransport {
             .ok_or_else(|| crate::Error::invalid_data("No interrupt IN endpoint found"))?;
 
         // Claim the interface
-        let interface = device
-            .claim_interface(interface_number)
-            .wait()
-            .map_err(crate::Error::Usb)?;
+        //
+        // macOS: IOKit doesn't publish interface services for vendor-class /
+        // class-0 devices with no matching driver. Force-set configuration 1
+        // so IOKit publishes them, then retry.
+        let interface = match device.claim_interface(interface_number).wait() {
+            Ok(iface) => iface,
+            #[cfg(target_os = "macos")]
+            Err(e) if Self::is_interface_unpublished(&e) => {
+                device
+                    .set_configuration(1)
+                    .wait()
+                    .map_err(crate::Error::Usb)?;
+                device
+                    .claim_interface(interface_number)
+                    .wait()
+                    .map_err(crate::Error::Usb)?
+            }
+            Err(e) => return Err(crate::Error::Usb(e)),
+        };
 
         // Open endpoints
         let bulk_in = interface


### PR DESCRIPTION
Exposes the building blocks needed for consumers to drive non-standard MTP devices end-to-end, without baking any device-specific knowledge into the crate. Closes vdavid/mtp-rs#3.

### PTP session
- **Public execution primitives:** `PtpSession::execute` / `execute_with_receive` / `execute_with_send` are now `pub`, reachable via a new `MtpDevice::session()` accessor.
- **Split header/data send mode:** `PtpSession::set_split_header_data(bool)` / `is_split_header_data()` make `execute_with_send` *and* `execute_with_send_stream` emit the 12-byte PTP container header and payload as separate bulk transfers, for devices that won't accept the combined form. Empty stream chunks are skipped in split mode so they aren't misinterpreted as end-of-transfer markers. Default behavior (single combined transfer) is unchanged.

### Device discovery & open
- **Custom VID/PID enumeration:** `MtpDevice::list_devices_with_known(&[(u16,u16)])` and `MtpDeviceBuilder::known_devices(...)` pick up devices whose USB descriptors don't advertise standard MTP class codes. Implemented in the transport via `NusbTransport::list_mtp_devices_with_known` and a fast-path in `is_mtp_device`.
- **Permissive interface scan on open:** `open_with_timeout` now does a two-pass scan — strict MTP-class match first, then any interface with the MTP endpoint layout (bulk IN + bulk OUT + interrupt IN). Safe because the caller has already hand-picked the device.
- **`MtpDeviceBuilder::open_nusb_device(nusb::Device)`:** escape hatch for callers doing their own enumeration / hotplug watching.
- **macOS `SetConfiguration(1)` retry:** on macOS, IOKit doesn't publish `IOUSBHostInterface` services for vendor-class / class-0 devices with no matching kext, so `claim_interface` returns `NotFound`. We now detect that and retry after forcing configuration 1, which is what coaxes IOKit into publishing the interface objects. Gated to `#[cfg(target_os = "macos")]`.

### Tests
New unit tests in [src/ptp/session/mod.rs](src/ptp/session/mod.rs) cover the send path against a mock transport: combined vs. split for both `execute_with_send` and `execute_with_send_stream`, plus empty-payload and empty-chunk edge cases in split mode.
