### PR TITLE
Add Garmin quirk and document FR955

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ storage.upload(Some(download.handle), file_info, data).await?;
 | Samsung Galaxy S23 Ultra (SM-S918B)              | 14      | No root listing |
 | [Amazon Kindle Paperwhite 12th Generation (2024)](https://github.com/vdavid/mtp-rs/pull/2#issuecomment-4264713119) | -       | Full support    |
 | [Fairphone 5](https://github.com/vdavid/mtp-rs/issues/6#issuecomment-4234861708) (e/OS 3.0.4, LineageOS-derived) | 13 | Full support |
+| [Garmin Forerunner 955](https://github.com/vdavid/mtp-rs/pull/10) | - | Very finicky |
 
 **Samsung quirk**: Samsung devices return `InvalidObjectHandle` when listing the root folder with handle 0.
 The library automatically detects this and falls back to recursive listing with filtering. This is transparent to users.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ storage.upload(Some(download.handle), file_info, data).await?;
 | Samsung Galaxy S23 Ultra (SM-S918B)              | 14      | No root listing |
 | [Amazon Kindle Paperwhite 12th Generation (2024)](https://github.com/vdavid/mtp-rs/pull/2#issuecomment-4264713119) | -       | Full support    |
 | [Fairphone 5](https://github.com/vdavid/mtp-rs/issues/6#issuecomment-4234861708) (e/OS 3.0.4, LineageOS-derived) | 13 | Full support |
-| [Garmin Forerunner 955](https://github.com/vdavid/mtp-rs/pull/10) | - | Very finicky |
+| [Garmin Forerunner 955](https://github.com/vdavid/mtp-rs/pull/10) | - | Works for app use; integration suite has one failing test under investigation |
 
 **Samsung quirk**: Samsung devices return `InvalidObjectHandle` when listing the root folder with handle 0.
 The library automatically detects this and falls back to recursive listing with filtering. This is transparent to users.

--- a/src/mtp/device.rs
+++ b/src/mtp/device.rs
@@ -535,6 +535,11 @@ impl MtpDeviceBuilder {
         // Get device info
         let device_info = session.get_device_info().await?;
 
+        // Quirk for Garmin devices
+        if device_info.manufacturer == "Garmin" {
+            session.set_split_header_data(true);
+        }
+
         let inner = Arc::new(MtpDeviceInner {
             session,
             device_info,


### PR DESCRIPTION
Test results:
```
running 11 tests
test readonly::slow_test_list_recursive ... [00:00:00.000] SKIPPING slow_test_list_recursive (set MTP_RUN_SLOW_TESTS=1 to run)
ok
test readonly::test_cancel_download_then_reuse_session ... [00:00:00.193] Searching for file (100KB-10MB) to cancel...
[00:00:03.346] Starting download of Eminem - Without Me.mp3 (4759554 bytes)
[00:00:03.366] Read 65536 bytes (1.4%), now cancelling...
[00:00:03.967] Cancel succeeded
[00:00:03.987] Session healthy: listed 4 root objects after cancel
[00:00:04.676] Second full download succeeded (4759554 bytes). Cancel test PASSED
ok
test readonly::test_custom_timeout ... [00:00:04.779] Opened with 60s timeout: Forerunner 955
ok
test readonly::test_device_connection ... [00:00:04.787] Connected: Garmin Forerunner 955 (0000d6a08d1e)
ok
test readonly::test_download_with_progress ... [00:00:04.793] Searching for file (100KB-10MB)...
[00:00:07.939] Downloading Eminem - Without Me.mp3 (4759554 bytes)
[00:00:08.026]   11%
[00:00:08.103]   22%
[00:00:08.180]   33%
[00:00:08.255]   44%
[00:00:08.330]   55%
[00:00:08.405]   66%
[00:00:08.480]   77%
[00:00:08.556]   88%
[00:00:08.630]   99%
[00:00:08.636] Download complete
ok
test readonly::test_drop_mid_stream_then_software_reconnect ... [00:00:08.636] SKIPPING: requires --release (debug_assert would panic)
ok
test readonly::test_list_root_folder ... [00:00:08.757] Root contains 4 objects
[00:00:08.757]   DIR             - GARMIN
[00:00:08.757]   DIR             - Music
[00:00:08.757]   DIR             - Audiobooks
[00:00:08.757]   DIR             - Podcasts
ok
test readonly::test_list_storages ... [00:00:08.765] Found 1 storage(s)
[00:00:08.765]   Internal Storage - 17.25 GB free / 31.06 GB total
ok
test readonly::test_ptp_device ...
thread 'readonly::test_ptp_device' (280968) panicked at tests/integration.rs:333:20:
get device info failed: InvalidData { message: "data container length mismatch: header says 281, have 12" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED
test readonly::test_refresh_storage ... [00:00:38.774] SKIPPING: open device - Timeout
[00:00:38.774]   Check: phone unlocked? USB authorized? Cable connected?
ok
test readonly::test_streaming_download ... [00:01:08.874] SKIPPING: open device - Timeout
[00:01:08.874]   Check: phone unlocked? USB authorized? Cable connected?
ok

failures:

failures:
    readonly::test_ptp_device

test result: FAILED. 10 passed; 1 failed; 0 ignored; 0 measured; 6 filtered out; finished in 68.88s
```