### PR TITLE
Support CLI for MTP file transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "clap",
  "futures",
  "futures-timer",
  "notify",
@@ -693,6 +694,8 @@ dependencies = [
  "nusb",
  "parking_lot",
  "proptest",
+ "serde",
+ "serde_json",
  "serial_test",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ exclude = [
 [package.metadata.docs.rs]
 all-features = true
 
+[[bin]]
+name = "mtp-rs"
+path = "src/bin/mtp-rs.rs"
+required-features = ["cli"]
+
 [dependencies]
 # USB transport (Phase 3+)
 nusb = "0.2"
@@ -48,6 +53,12 @@ thiserror = "2"
 # Enum conversion derives
 num_enum = "0.7"
 
+# CLI
+clap = { version = "4.5", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+tokio = { version = "1.35", features = ["rt-multi-thread", "macros", "time", "fs", "io-util"], optional = true }
+
 [dev-dependencies]
 tokio = { version = "1.35", features = ["rt-multi-thread", "macros", "time", "fs", "io-util"] }
 proptest = "1"
@@ -57,4 +68,5 @@ tempfile = "3"
 
 [features]
 default = []
+cli = ["clap", "serde", "serde_json", "tokio"]
 virtual-device = ["notify"]

--- a/README.md
+++ b/README.md
@@ -124,9 +124,62 @@ the most common choice:
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-### Platform notes
+## CLI
 
-#### Linux
+`mtp-rs` also ships a universal MTP file-transfer CLI. It is not tied to a
+specific device brand: Android phones, Kindles, Garmin watches, media players,
+and other MTP devices all use the same `devices`, `info`, `ls`, `put`, `get`,
+`mkdir`, `rm`, `rename`, `mv`, `cp`, and `doctor` commands.
+
+Install it with the `cli` feature:
+
+```sh
+cargo install mtp-rs --features cli
+```
+
+```sh
+# List visible devices
+mtp-rs devices
+mtp-rs devices --json
+
+# Inspect the selected device and its storages
+mtp-rs info --device SERIAL
+
+# List files
+mtp-rs ls /
+mtp-rs ls /Music --recursive
+
+# Upload and download files
+mtp-rs put ./song.mp3 /Music/song.mp3 --replace
+mtp-rs get /Music/song.mp3 ./song.mp3
+
+# Create and remove remote objects
+mtp-rs mkdir /Upload
+mtp-rs rm /Upload/old.bin --yes
+
+# Rename, move, and copy remote objects
+mtp-rs rename /Upload/old.bin new.bin
+mtp-rs mv /Upload/new.bin /Archive/new.bin
+mtp-rs cp /Archive/new.bin /Archive/new-copy.bin
+
+# Diagnose access, storage, and common USB ownership issues
+mtp-rs doctor
+```
+
+Remote paths are POSIX-like and absolute: `/`, `/Music/song.mp3`,
+`/GARMIN/APPS/app.prg`. Device-specific workflows are expressed through normal
+file operations. For example, Garmin Connect IQ sideloading is just:
+
+```sh
+mtp-rs put ./MyApp.prg /GARMIN/APPS/MyApp.prg --replace --verify
+```
+
+See [docs/cli.md](docs/cli.md) for command reference, path semantics, JSON
+output, exit codes, and troubleshooting.
+
+## Platform notes
+
+### Linux
 
 You may need udev rules to access USB devices without root. Create `/etc/udev/rules.d/99-mtp.rules`:
 
@@ -136,7 +189,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="*",  MODE="0666"
 
 Then run `sudo udevadm control --reload-rules`.
 
-#### macOS
+### macOS
 
 It's a bit of a nightmare because macOS's built-in `ptpcamerad` daemon automatically claims MTP/PTP devices right on
 connection, blocking other apps. This sucks because it it NOT `MTP`, just `PTP`, so Android phones, Kindles, etc.
@@ -146,6 +199,11 @@ this) will be unable to access the device. 🤯
 One more potential offender is [Android File Transfer](https://www.android-file-transfer-mac.com/): If installed, it
 spawns a process that also grabs devices. You must quit it before trying to connect to an MTP device using this (or,
 honestly, any) library.
+
+Recent macOS versions can also deny USB user-client access to processes that are launched from background agents or
+tool runners instead of a normal app/Terminal context. In that case the device may appear in `mtp-rs devices`, but open
+fails while creating the IOKit PlugInInterface. Try running the CLI from Terminal or iTerm with the Mac unlocked and the
+accessory allowed.
 
 **Workarounds:**
 
@@ -172,7 +230,7 @@ honestly, any) library.
 - See [Cmdr](https://github.com/vdavid/cmdr) and [Commander One](https://mac.eltima.com/file-manager.html) for UX
   inspiration on handling this gracefully.
 
-#### Windows
+### Windows
 
 Should work, and no dependencies needed, but we haven't tested it.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,373 @@
+# mtp-rs CLI
+
+`mtp-rs` includes a universal MTP file-transfer CLI. It is intentionally
+device-neutral: Garmin watches, Android phones, Kindles, media players, and
+cameras that expose MTP storage all use the same file commands.
+
+## Installation
+
+Install the binary with the `cli` feature:
+
+```sh
+cargo install mtp-rs --features cli
+```
+
+If you are working from a checkout:
+
+```sh
+cargo run --features cli --bin mtp-rs -- devices
+```
+
+## Quick Start
+
+```sh
+# Show visible devices.
+mtp-rs devices
+
+# Inspect a specific device and its storages.
+mtp-rs info --device SERIAL
+
+# List files.
+mtp-rs ls /
+mtp-rs ls /Music --recursive
+
+# Upload and download files.
+mtp-rs put ./song.mp3 /Music/song.mp3 --replace
+mtp-rs get /Music/song.mp3 ./song.mp3
+
+# Create and remove remote objects.
+mtp-rs mkdir /Upload
+mtp-rs rm /Upload/old.bin --yes
+
+# Rename, move, and copy remote objects.
+mtp-rs rename /Upload/old.bin new.bin
+mtp-rs mv /Upload/new.bin /Archive/new.bin
+mtp-rs cp /Archive/new.bin /Archive/new-copy.bin
+
+# Diagnose common MTP access problems.
+mtp-rs doctor
+```
+
+## Global Options
+
+| Option | Description |
+| --- | --- |
+| `--device SERIAL` | Select a physical device by serial number. |
+| `--location HEX_OR_DECIMAL` | Select the USB location shown by `devices`. |
+| `--storage INDEX_OR_ID` | Select a storage by zero-based index or storage ID. |
+| `--known VID:PID` | Include a non-standard MTP device in discovery. Can be repeated. |
+| `--timeout SECONDS` | Set the USB transfer timeout. Defaults to 30 seconds. |
+| `--json` | Emit machine-readable JSON for every command. Transfer progress still goes to stderr. |
+| `--verbose` | Include lower-level protocol or transport error detail. |
+
+`--device` and `--location` are mutually exclusive. If neither is passed,
+commands open the only visible MTP device. If multiple devices are visible,
+pass one of them explicitly.
+
+Mutating commands select the first storage only when the device exposes a
+single storage. If a device exposes multiple storages, pass `--storage` for
+`put`, `mkdir`, `rm`, `rename`, `mv`, and `cp`.
+
+## Remote Paths
+
+Remote paths are POSIX-like and absolute:
+
+```text
+/
+/Music/song.mp3
+/Download/report.pdf
+/GARMIN/APPS/MyApp.prg
+```
+
+Path matching is case-sensitive in v1 because MTP devices disagree about
+case behavior. Components containing `/`, `\`, null bytes, `.`, or `..` are
+rejected before sending an MTP request.
+
+For destination paths:
+
+- `DEST/` means “use the source or local filename inside `DEST`”.
+- If `DEST` exists and is a folder, the command writes inside that folder.
+- If a destination file exists, pass `--replace` where supported.
+
+## Commands
+
+### `devices`
+
+List visible MTP devices.
+
+```sh
+mtp-rs devices
+mtp-rs devices --json
+mtp-rs devices --known 091e:0003
+```
+
+The output includes VID/PID, manufacturer, product, serial number, USB
+location, negotiated link speed when the OS reports it, and `match_reason`.
+`match_reason` explains why the device was accepted as an MTP candidate:
+`standard_class`, `interface_string`, `known_vid_pid`, or
+`opened_descriptor_scan`.
+
+### `info`
+
+Open a device and show device metadata plus storages.
+
+```sh
+mtp-rs info
+mtp-rs info --device SERIAL
+mtp-rs info --location 0xffff000000000000 --json
+```
+
+Use this before mutating commands when the device has multiple storages.
+
+### `ls`
+
+List a remote folder.
+
+```sh
+mtp-rs ls /
+mtp-rs ls /Music
+mtp-rs ls /Music --recursive
+mtp-rs ls / --storage 0 --json
+```
+
+`ls` requires the path to resolve to a folder.
+
+### `put`
+
+Upload a local file to a remote path.
+
+```sh
+mtp-rs put ./song.mp3 /Music/song.mp3
+mtp-rs put ./song.mp3 /Music/ --replace
+mtp-rs put ./MyApp.prg /GARMIN/APPS/MyApp.prg --replace --verify
+```
+
+Behavior:
+
+- If `REMOTE_PATH` ends with `/`, the local filename is used.
+- If `REMOTE_PATH` resolves to an existing folder, the file is uploaded inside it.
+- If the destination file exists, `--replace` deletes it before upload.
+- `--verify` downloads the uploaded object back and compares bytes. This is
+  intentionally explicit because it doubles transfer traffic.
+
+Uploads are streamed; large files are not buffered in memory.
+
+### `get`
+
+Download a remote file to a local path.
+
+```sh
+mtp-rs get /Music/song.mp3 ./song.mp3
+mtp-rs get /Music/song.mp3 ./song.mp3 --replace
+```
+
+`get --replace` writes to a temporary file first and replaces the destination
+only after the download succeeds, so an interrupted transfer does not destroy
+the existing local file.
+
+### `mkdir`
+
+Create one remote folder under an existing parent.
+
+```sh
+mtp-rs mkdir /Upload
+mtp-rs mkdir /GARMIN/APPS
+```
+
+This does not create missing intermediate folders.
+
+### `rm`
+
+Delete a remote object.
+
+```sh
+mtp-rs rm /Upload/old.bin --yes
+```
+
+`--yes` is required. Folder deletion depends on what the device supports; many
+devices reject non-empty folder deletes.
+
+### `rename`
+
+Rename a remote object in place.
+
+```sh
+mtp-rs rename /Upload/old.bin new.bin
+```
+
+`new.bin` must be a filename, not a path. The device must advertise rename
+support.
+
+### `mv`
+
+Move a remote object to another folder or path.
+
+```sh
+mtp-rs mv /Upload/file.bin /Archive/file.bin
+mtp-rs mv /Upload/file.bin /Archive/
+mtp-rs mv /Upload/file.bin /Archive/new-name.bin
+```
+
+If the destination changes the filename, the device must support rename.
+If the destination file exists, pass `--replace`.
+
+### `cp`
+
+Copy a remote object to another folder or path.
+
+```sh
+mtp-rs cp /Upload/file.bin /Archive/file.bin
+mtp-rs cp /Upload/file.bin /Archive/
+mtp-rs cp /Upload/file.bin /Archive/file-copy.bin
+```
+
+If the destination changes the filename, the device must support rename.
+If the destination file exists, pass `--replace`.
+
+### `doctor`
+
+Diagnose common discovery and access problems.
+
+```sh
+mtp-rs doctor
+mtp-rs doctor --device SERIAL --json
+```
+
+`doctor` checks visible devices, open behavior, storages, root listing, and
+common writable-folder hints such as `Download`, `Documents`, `Music`, and
+`GARMIN`. In JSON mode it keeps the visible device rows, including
+`match_reason`, even when opening the selected device fails.
+
+## JSON Output
+
+Pass `--json` to any command for machine-readable output:
+
+```sh
+mtp-rs devices --json
+mtp-rs info --json
+mtp-rs put ./song.mp3 /Music/song.mp3 --json
+```
+
+JSON is written to stdout. Transfer progress is written to stderr, so stdout
+remains parseable JSON during `put`, `get`, and `put --verify`.
+
+For mutating commands, JSON includes an `operation` field and relevant paths,
+handles, filenames, byte counts, and booleans such as `verified`, `renamed`,
+or `replaced`. `replaced` means an existing visible destination object was
+actually replaced.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Other error. |
+| `2` | No device found. |
+| `3` | Ambiguous device or storage selection. |
+| `4` | Access denied, read-only storage, or exclusive access. |
+| `5` | Remote path error. |
+| `6` | Transfer failed. |
+| `7` | Verification failed. |
+
+Use `--verbose` when an automation needs lower-level protocol context in
+stderr.
+
+## Device Workflows
+
+### Android
+
+Android devices usually reject uploads to the storage root. Upload into an
+existing folder such as `Download`:
+
+```sh
+mtp-rs put ./report.pdf /Download/report.pdf --replace
+mtp-rs get /Download/report.pdf ./report.pdf
+```
+
+Make sure the phone is unlocked and USB mode is set to file transfer.
+
+### Kindle
+
+Copy documents into the documents folder:
+
+```sh
+mtp-rs put ./book.epub /documents/book.epub --replace
+mtp-rs ls /documents
+```
+
+### Garmin
+
+Connect IQ sideloading is a normal file upload:
+
+```sh
+mtp-rs put ./MyApp.prg /GARMIN/APPS/MyApp.prg --replace --verify
+```
+
+Garmin remains just one workflow; the CLI does not include Garmin-specific
+commands.
+
+### Generic Backup
+
+Download files by path after listing folders:
+
+```sh
+mtp-rs ls /DCIM --recursive
+mtp-rs get /DCIM/Camera/IMG_0001.jpg ./IMG_0001.jpg
+```
+
+## Troubleshooting
+
+### No Device Found
+
+Check that the device is connected, unlocked, and in MTP/file-transfer mode.
+Some devices expose different USB modes for charging, PTP, tethering, and MTP.
+
+### Multiple Devices
+
+Run:
+
+```sh
+mtp-rs devices
+```
+
+Then repeat the command with `--device SERIAL` or `--location LOCATION`.
+
+### Multiple Storages
+
+Run:
+
+```sh
+mtp-rs info
+```
+
+Then pass `--storage INDEX_OR_ID` to mutating commands.
+
+### macOS Exclusive Access
+
+macOS may let Photos, `ptpcamerad`, Android File Transfer, Garmin Express, or
+another file manager claim the USB device. Close those applications and retry.
+The CLI detects common exclusive-access errors and prints a practical hint.
+
+### macOS USB Authorization
+
+On recent macOS versions, IOKit can also deny USB user-client access before the
+device is opened. This is different from another app owning the interface: the
+device is visible in `mtp-rs devices`, but `info`, `ls`, or `doctor` fail while
+creating the IOKit PlugInInterface. Run the CLI from Terminal or iTerm with the
+Mac unlocked and the accessory allowed. GUI helpers launched as normal `.app`
+bundles can have different USB authorization than background agents or IDE task
+runners.
+
+### Linux Permissions
+
+You may need udev rules to access USB devices without root. See the platform
+notes in the main [README](../README.md#linux).
+
+### Timeout Or Disconnect
+
+Use a better cable or port, unlock the device, avoid sleep/lock during transfer,
+and increase timeout for large files:
+
+```sh
+mtp-rs --timeout 120 put ./large-video.mp4 /Movies/large-video.mp4
+```

--- a/src/bin/mtp-rs.rs
+++ b/src/bin/mtp-rs.rs
@@ -3,6 +3,8 @@ mod cli;
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
+    register_test_virtual_device();
+
     match cli::run().await {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(err) => {
@@ -14,3 +16,30 @@ async fn main() -> std::process::ExitCode {
         }
     }
 }
+
+#[cfg(all(feature = "virtual-device", debug_assertions))]
+fn register_test_virtual_device() {
+    let Ok(root) = std::env::var("__MTP_RS_TEST_VIRTUAL_ROOT") else {
+        return;
+    };
+    let serial = std::env::var("__MTP_RS_TEST_VIRTUAL_SERIAL")
+        .unwrap_or_else(|_| "mtp-rs-cli-test".to_string());
+    let config = mtp_rs::VirtualDeviceConfig {
+        manufacturer: "TestCorp".into(),
+        model: "CLI Test Device".into(),
+        serial,
+        storages: vec![mtp_rs::VirtualStorageConfig {
+            description: "Internal Storage".into(),
+            capacity: 64 * 1024 * 1024,
+            backing_dir: std::path::PathBuf::from(root),
+            read_only: false,
+        }],
+        supports_rename: true,
+        event_poll_interval: std::time::Duration::ZERO,
+        watch_backing_dirs: false,
+    };
+    let _ = mtp_rs::register_virtual_device(&config);
+}
+
+#[cfg(not(all(feature = "virtual-device", debug_assertions)))]
+fn register_test_virtual_device() {}

--- a/src/bin/mtp-rs.rs
+++ b/src/bin/mtp-rs.rs
@@ -1,0 +1,16 @@
+#[path = "../cli/mod.rs"]
+mod cli;
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    match cli::run().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            if let Some(help) = err.help() {
+                eprintln!("{}", help);
+            }
+            std::process::ExitCode::from(err.exit_code())
+        }
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,258 @@
+use clap::{Args, Parser, Subcommand};
+use std::str::FromStr;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "mtp-rs",
+    about = "Universal MTP/PTP file transfer CLI",
+    version
+)]
+pub struct Cli {
+    /// Device serial number to open.
+    #[arg(long, global = true, conflicts_with = "location")]
+    pub device: Option<String>,
+
+    /// USB location ID to open, as decimal or hex.
+    #[arg(long, global = true, value_parser = parse_u64_hex_or_dec, conflicts_with = "device")]
+    pub location: Option<u64>,
+
+    /// Storage index or storage ID. Decimal indexes are tried first.
+    #[arg(long, global = true)]
+    pub storage: Option<String>,
+
+    /// Include a non-standard MTP device by VID:PID.
+    #[arg(long, global = true, value_parser = parse_vid_pid)]
+    pub known: Vec<(u16, u16)>,
+
+    /// USB transfer timeout in seconds.
+    #[arg(long, global = true, default_value_t = 30)]
+    pub timeout: u64,
+
+    /// Emit machine-readable JSON where supported.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Include lower-level error detail.
+    #[arg(long, short, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// List visible MTP devices.
+    Devices,
+
+    /// Show device and storage information.
+    Info,
+
+    /// List objects in a remote folder.
+    Ls(LsArgs),
+
+    /// Upload a local file to a remote path.
+    Put(PutArgs),
+
+    /// Download a remote file to a local path.
+    Get(GetArgs),
+
+    /// Create one remote folder.
+    Mkdir(RemotePathArg),
+
+    /// Delete a remote object.
+    Rm(RmArgs),
+
+    /// Rename a remote object in place.
+    Rename(RenameArgs),
+
+    /// Move a remote object to another folder or path.
+    Mv(MoveArgs),
+
+    /// Copy a remote object to another folder or path.
+    Cp(CopyArgs),
+
+    /// Diagnose device visibility and basic MTP access.
+    Doctor,
+}
+
+#[derive(Debug, Args)]
+pub struct LsArgs {
+    /// Remote folder path.
+    #[arg(default_value = "/")]
+    pub remote_path: String,
+
+    /// List descendants recursively.
+    #[arg(long)]
+    pub recursive: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct PutArgs {
+    /// Local file path.
+    pub local_path: std::path::PathBuf,
+
+    /// Remote destination path.
+    pub remote_path: String,
+
+    /// Replace a visible existing remote file.
+    #[arg(long)]
+    pub replace: bool,
+
+    /// Download back and compare bytes after upload.
+    #[arg(long)]
+    pub verify: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct GetArgs {
+    /// Remote file path.
+    pub remote_path: String,
+
+    /// Local destination path.
+    pub local_path: std::path::PathBuf,
+
+    /// Replace an existing local file.
+    #[arg(long)]
+    pub replace: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RemotePathArg {
+    /// Remote path.
+    pub remote_path: String,
+}
+
+#[derive(Debug, Args)]
+pub struct RmArgs {
+    /// Remote path.
+    pub remote_path: String,
+
+    /// Confirm deletion.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RenameArgs {
+    /// Remote object path.
+    pub remote_path: String,
+
+    /// New filename, not a path.
+    pub new_name: String,
+}
+
+#[derive(Debug, Args)]
+pub struct MoveArgs {
+    /// Remote source path.
+    pub source_path: String,
+
+    /// Remote destination path or folder.
+    pub destination_path: String,
+
+    /// Replace a visible existing destination object.
+    #[arg(long)]
+    pub replace: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct CopyArgs {
+    /// Remote source path.
+    pub source_path: String,
+
+    /// Remote destination path or folder.
+    pub destination_path: String,
+
+    /// Replace a visible existing destination object.
+    #[arg(long)]
+    pub replace: bool,
+}
+
+fn parse_vid_pid(input: &str) -> Result<(u16, u16), String> {
+    let (vid, pid) = input
+        .split_once(':')
+        .ok_or_else(|| "expected VID:PID, for example 091e:0003".to_string())?;
+    Ok((parse_u16_hex(vid)?, parse_u16_hex(pid)?))
+}
+
+fn parse_u16_hex(input: &str) -> Result<u16, String> {
+    let trimmed = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+        .unwrap_or(input);
+    u16::from_str_radix(trimmed, 16).map_err(|_| format!("invalid hex u16 value '{input}'"))
+}
+
+pub fn parse_u64_hex_or_dec(input: &str) -> Result<u64, String> {
+    if let Some(hex) = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+    {
+        return u64::from_str_radix(hex, 16)
+            .map_err(|_| format!("invalid hex u64 value '{input}'"));
+    }
+
+    if input.chars().any(|c| matches!(c, 'a'..='f' | 'A'..='F')) {
+        return u64::from_str_radix(input, 16)
+            .map_err(|_| format!("invalid hex u64 value '{input}'"));
+    }
+
+    u64::from_str(input).map_err(|_| format!("invalid decimal u64 value '{input}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn clap_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn commands_parse() {
+        for args in [
+            ["mtp-rs", "devices"].as_slice(),
+            ["mtp-rs", "info"].as_slice(),
+            ["mtp-rs", "ls", "/"].as_slice(),
+            ["mtp-rs", "put", "local.bin", "/remote.bin"].as_slice(),
+            ["mtp-rs", "get", "/remote.bin", "local.bin"].as_slice(),
+            ["mtp-rs", "mkdir", "/Upload"].as_slice(),
+            ["mtp-rs", "rm", "/Upload/old.bin", "--yes"].as_slice(),
+            ["mtp-rs", "rename", "/Upload/old.bin", "new.bin"].as_slice(),
+            ["mtp-rs", "mv", "/Upload/file.bin", "/Archive/file.bin"].as_slice(),
+            ["mtp-rs", "cp", "/Upload/file.bin", "/Archive/file.bin"].as_slice(),
+            ["mtp-rs", "doctor"].as_slice(),
+        ] {
+            Cli::try_parse_from(args.iter().copied()).unwrap();
+        }
+    }
+
+    #[test]
+    fn device_and_location_conflict() {
+        assert!(
+            Cli::try_parse_from(["mtp-rs", "--device", "serial", "--location", "0x1", "info"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn known_vid_pid_accepts_hex_pair() {
+        assert_eq!(parse_vid_pid("091e:0003").unwrap(), (0x091e, 0x0003));
+        assert_eq!(parse_vid_pid("0x091e:0x0003").unwrap(), (0x091e, 0x0003));
+    }
+
+    #[test]
+    fn known_vid_pid_rejects_malformed_input() {
+        assert!(parse_vid_pid("091e").is_err());
+        assert!(parse_vid_pid("nope:0003").is_err());
+    }
+
+    #[test]
+    fn location_parser_accepts_decimal_and_hex() {
+        assert_eq!(parse_u64_hex_or_dec("42").unwrap(), 42);
+        assert_eq!(parse_u64_hex_or_dec("0x2a").unwrap(), 42);
+        assert_eq!(parse_u64_hex_or_dec("2a").unwrap(), 42);
+    }
+}

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,0 +1,179 @@
+use mtp_rs::{Error, ResponseCode};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliErrorKind {
+    Other,
+    NoDevice,
+    AmbiguousSelection,
+    AccessDenied,
+    RemotePath,
+    Transfer,
+    Verify,
+}
+
+impl CliErrorKind {
+    #[must_use]
+    pub fn exit_code(self) -> u8 {
+        match self {
+            Self::Other => 1,
+            Self::NoDevice => 2,
+            Self::AmbiguousSelection => 3,
+            Self::AccessDenied => 4,
+            Self::RemotePath => 5,
+            Self::Transfer => 6,
+            Self::Verify => 7,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CliError {
+    kind: CliErrorKind,
+    message: String,
+    detail: Option<String>,
+    help: Option<String>,
+}
+
+impl CliError {
+    #[must_use]
+    pub fn new(kind: CliErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            detail: None,
+            help: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    #[must_use]
+    pub fn from_mtp(context: &str, error: Error, verbose: bool) -> Self {
+        let detail = verbose.then(|| format!("{error:?}"));
+        let mut cli_error = if is_macos_usb_user_client_denied(&error) {
+            Self::new(
+                CliErrorKind::AccessDenied,
+                format!("{context}: macOS denied USB access for this process"),
+            )
+            .with_help(macos_usb_user_client_help())
+        } else if error.is_exclusive_access() {
+            Self::new(
+                CliErrorKind::AccessDenied,
+                format!("{context}: device is already in use"),
+            )
+            .with_help(exclusive_access_help())
+        } else {
+            match &error {
+                Error::NoDevice => Self::new(CliErrorKind::NoDevice, "no MTP device found"),
+                Error::Timeout => {
+                    Self::new(CliErrorKind::Transfer, format!("{context}: timed out"))
+                }
+                Error::Disconnected => Self::new(
+                    CliErrorKind::Transfer,
+                    format!("{context}: device disconnected"),
+                ),
+                Error::Protocol { code, .. } => protocol_error(context, *code),
+                Error::Io(io) => {
+                    Self::new(CliErrorKind::Other, format!("{context}: I/O error: {io}"))
+                }
+                _ => Self::new(CliErrorKind::Other, format!("{context}: {error}")),
+            }
+        };
+
+        if let Some(detail) = detail {
+            cli_error = cli_error.with_detail(detail);
+        }
+        cli_error
+    }
+
+    #[must_use]
+    pub fn exit_code(&self) -> u8 {
+        self.kind.exit_code()
+    }
+
+    #[must_use]
+    pub fn help(&self) -> Option<&str> {
+        self.help.as_deref()
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.detail {
+            Some(detail) => write!(f, "{} ({detail})", self.message),
+            None => f.write_str(&self.message),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+fn protocol_error(context: &str, code: ResponseCode) -> CliError {
+    match code {
+        ResponseCode::InvalidObjectHandle | ResponseCode::InvalidParentObject => CliError::new(
+            CliErrorKind::RemotePath,
+            format!("{context}: remote path not found"),
+        ),
+        ResponseCode::InvalidStorageId => CliError::new(
+            CliErrorKind::RemotePath,
+            format!("{context}: invalid storage"),
+        ),
+        ResponseCode::StoreFull => CliError::new(
+            CliErrorKind::Transfer,
+            format!("{context}: storage is full"),
+        ),
+        ResponseCode::StoreReadOnly | ResponseCode::ObjectWriteProtected => CliError::new(
+            CliErrorKind::AccessDenied,
+            format!("{context}: storage is read-only"),
+        ),
+        ResponseCode::AccessDenied => CliError::new(
+            CliErrorKind::AccessDenied,
+            format!("{context}: access denied"),
+        ),
+        _ => CliError::new(
+            CliErrorKind::Transfer,
+            format!("{context}: protocol error {code:?}"),
+        ),
+    }
+}
+
+fn exclusive_access_help() -> &'static str {
+    "Close other applications that may own the USB device, such as Photos, Android File Transfer, Garmin Express, or another file manager."
+}
+
+fn macos_usb_user_client_help() -> &'static str {
+    "macOS can deny USB user-client access to non-app or background-launched processes. Try running mtp-rs from Terminal/iTerm with the Mac unlocked and the accessory allowed, or launch it from a signed app/helper context."
+}
+
+fn is_macos_usb_user_client_denied(error: &Error) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        const K_IO_RETURN_NO_RESOURCES: u32 = 0xe00002be;
+        match error {
+            Error::Usb(usb) => {
+                usb.os_error() == Some(K_IO_RETURN_NO_RESOURCES)
+                    && usb
+                        .to_string()
+                        .contains("failed to create IOKit PlugInInterface")
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = error;
+        false
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,1412 @@
+mod args;
+mod error;
+mod path;
+
+use args::{Cli, Command};
+use bytes::Bytes;
+use clap::Parser;
+use error::{CliError, CliErrorKind};
+use futures::Stream;
+use mtp_rs::mtp::{MtpDeviceInfo, Storage};
+use mtp_rs::ptp::ObjectInfo;
+use mtp_rs::{MtpDevice, NewObjectInfo, ObjectHandle, StorageId};
+use path::{ExistingRemote, RemotePath};
+use serde::Serialize;
+use std::io::Write;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const CHUNK_SIZE: usize = 256 * 1024;
+
+pub async fn run() -> Result<(), CliError> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Command::Devices => devices(&cli),
+        Command::Info => info(&cli).await,
+        Command::Ls(args) => ls(&cli, &args.remote_path, args.recursive).await,
+        Command::Put(args) => {
+            put(
+                &cli,
+                &args.local_path,
+                &args.remote_path,
+                args.replace,
+                args.verify,
+            )
+            .await
+        }
+        Command::Get(args) => get(&cli, &args.remote_path, &args.local_path, args.replace).await,
+        Command::Mkdir(args) => mkdir(&cli, &args.remote_path).await,
+        Command::Rm(args) => rm(&cli, &args.remote_path, args.yes).await,
+        Command::Rename(args) => rename(&cli, &args.remote_path, &args.new_name).await,
+        Command::Mv(args) => {
+            move_remote(
+                &cli,
+                &args.source_path,
+                &args.destination_path,
+                args.replace,
+            )
+            .await
+        }
+        Command::Cp(args) => {
+            copy_remote(
+                &cli,
+                &args.source_path,
+                &args.destination_path,
+                args.replace,
+            )
+            .await
+        }
+        Command::Doctor => doctor(&cli).await,
+    }
+}
+
+fn devices(cli: &Cli) -> Result<(), CliError> {
+    let devices = MtpDevice::list_devices_with_known(&cli.known)
+        .map_err(|e| CliError::from_mtp("list devices", e, cli.verbose))?;
+    let rows: Vec<DeviceRow> = devices.iter().map(DeviceRow::from).collect();
+
+    if cli.json {
+        print_json(&rows)
+    } else {
+        if rows.is_empty() {
+            println!("No MTP devices found");
+            return Ok(());
+        }
+        for row in rows {
+            println!(
+                "{} {} {:04x}:{:04x} serial={} location={} speed={}",
+                row.manufacturer.as_deref().unwrap_or("Unknown"),
+                row.product.as_deref().unwrap_or("Unknown"),
+                row.vendor_id,
+                row.product_id,
+                row.serial_number.as_deref().unwrap_or("-"),
+                row.location,
+                row.speed.as_deref().unwrap_or("unknown"),
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn info(cli: &Cli) -> Result<(), CliError> {
+    let device = open_selected_device(cli).await?;
+    let storages = device
+        .storages()
+        .await
+        .map_err(|e| CliError::from_mtp("list storages", e, cli.verbose))?;
+    let row = InfoRow {
+        manufacturer: device.device_info().manufacturer.clone(),
+        model: device.device_info().model.clone(),
+        serial_number: device.device_info().serial_number.clone(),
+        device_version: device.device_info().device_version.clone(),
+        supports_rename: device.supports_rename(),
+        storages: storages
+            .iter()
+            .enumerate()
+            .map(|(index, storage)| StorageRow::from_storage(index, storage))
+            .collect(),
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!(
+            "{} {} serial={} version={}",
+            row.manufacturer, row.model, row.serial_number, row.device_version
+        );
+        println!("supports rename: {}", row.supports_rename);
+        for storage in row.storages {
+            println!(
+                "[{}] id={} {} free={} capacity={} access={}",
+                storage.index,
+                storage.id,
+                storage.description,
+                storage.free_space_bytes,
+                storage.max_capacity,
+                storage.access_capability
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn ls(cli: &Cli, remote_path: &str, recursive: bool) -> Result<(), CliError> {
+    let (_device, storage) = open_storage(cli, false).await?;
+    let path = RemotePath::parse(remote_path)?;
+    let (parent, listed_path) = folder_parent(&storage, &path, cli.verbose).await?;
+    let objects = if recursive {
+        storage
+            .list_objects_recursive(parent)
+            .await
+            .map_err(|e| CliError::from_mtp("list remote folder", e, cli.verbose))?
+    } else {
+        storage
+            .list_objects(parent)
+            .await
+            .map_err(|e| CliError::from_mtp("list remote folder", e, cli.verbose))?
+    };
+    let rows: Vec<ObjectRow> = objects.iter().map(ObjectRow::from).collect();
+
+    if cli.json {
+        print_json(&LsRow {
+            path: listed_path,
+            recursive,
+            objects: rows,
+        })
+    } else {
+        for row in rows {
+            let kind = if row.kind == "folder" { "DIR " } else { "FILE" };
+            println!(
+                "{} {:>12} handle={} {}",
+                kind, row.size, row.handle, row.filename
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn put(
+    cli: &Cli,
+    local_path: &Path,
+    remote_path: &str,
+    replace: bool,
+    verify: bool,
+) -> Result<(), CliError> {
+    let metadata = tokio::fs::metadata(local_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("read local file: {e}")))?;
+    if !metadata.is_file() {
+        return Err(CliError::new(
+            CliErrorKind::Other,
+            "local path is not a regular file",
+        ));
+    }
+
+    let local_filename = local_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| CliError::new(CliErrorKind::Other, "local file has no valid filename"))?;
+    path::validate_component(local_filename)?;
+
+    let (_device, storage) = open_storage(cli, true).await?;
+    let remote_path = RemotePath::parse(remote_path)?;
+    let target =
+        path::resolve_upload_target(&storage, &remote_path, local_filename, cli.verbose).await?;
+
+    let replaced = target.existing.is_some();
+    if let Some(existing) = &target.existing {
+        if !replace {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote file already exists; pass --replace to delete it first",
+            ));
+        }
+        storage
+            .delete(existing.handle)
+            .await
+            .map_err(|e| CliError::from_mtp("delete existing remote file", e, cli.verbose))?;
+    }
+
+    let file = tokio::fs::File::open(local_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("open local file: {e}")))?;
+    let total_size = metadata.len();
+    let stream = file_stream(file);
+    let info = NewObjectInfo::file(target.filename.clone(), total_size);
+    let mut last_percent = 101u64;
+    let handle = storage
+        .upload_with_progress(target.parent, info, stream, |progress| {
+            print_progress(
+                "upload",
+                progress.bytes_transferred,
+                total_size,
+                &mut last_percent,
+            );
+            ControlFlow::Continue(())
+        })
+        .await
+        .map_err(|e| CliError::from_mtp("upload file", e, cli.verbose))?;
+    finish_progress();
+    let mut verified = false;
+
+    if verify {
+        verify_remote_matches_local(&storage, handle, local_path, total_size, cli.verbose).await?;
+        verified = true;
+    }
+
+    let row = PutRow {
+        operation: "put",
+        local_path: local_path.display().to_string(),
+        remote_path: remote_path.raw().to_string(),
+        filename: target.filename,
+        handle: handle.0,
+        bytes: total_size,
+        replaced,
+        verified,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!(
+            "uploaded {} ({} bytes) handle={}",
+            row.filename, row.bytes, row.handle
+        );
+        if row.verified {
+            println!("verified {}", row.filename);
+        }
+        Ok(())
+    }
+}
+
+async fn get(
+    cli: &Cli,
+    remote_path: &str,
+    local_path: &Path,
+    replace: bool,
+) -> Result<(), CliError> {
+    let destination_exists = tokio::fs::try_exists(local_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("check local path: {e}")))?;
+    if destination_exists && !replace {
+        return Err(CliError::new(
+            CliErrorKind::Other,
+            "local file already exists; pass --replace to overwrite it",
+        ));
+    }
+
+    let (_device, storage) = open_storage(cli, false).await?;
+    let path = RemotePath::parse(remote_path)?;
+    let object = match path::resolve_existing(&storage, &path, cli.verbose).await? {
+        ExistingRemote::Root => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "cannot download the storage root",
+            ));
+        }
+        ExistingRemote::Object(object) if object.is_file() => object,
+        ExistingRemote::Object(_) => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote path is not a file",
+            ));
+        }
+    };
+
+    let mut download = storage
+        .download_stream(object.handle)
+        .await
+        .map_err(|e| CliError::from_mtp("start download", e, cli.verbose))?;
+    let temp_path = temp_download_path(local_path);
+    let mut out = tokio::fs::File::create(&temp_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("create local file: {e}")))?;
+    let mut last_percent = 101u64;
+
+    let download_result = async {
+        while let Some(chunk) = download.next_chunk().await {
+            let bytes = chunk.map_err(|e| CliError::from_mtp("download file", e, cli.verbose))?;
+            out.write_all(&bytes).await.map_err(|e| {
+                CliError::new(CliErrorKind::Transfer, format!("write local file: {e}"))
+            })?;
+            print_progress(
+                "download",
+                download.bytes_received(),
+                download.size(),
+                &mut last_percent,
+            );
+        }
+        out.flush()
+            .await
+            .map_err(|e| CliError::new(CliErrorKind::Transfer, format!("flush local file: {e}")))?;
+        Ok::<(), CliError>(())
+    }
+    .await;
+    drop(out);
+
+    if let Err(err) = download_result {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        finish_progress();
+        return Err(err);
+    }
+
+    if destination_exists && replace {
+        tokio::fs::remove_file(local_path)
+            .await
+            .map_err(|e| CliError::new(CliErrorKind::Other, format!("replace local file: {e}")))?;
+    }
+    tokio::fs::rename(&temp_path, local_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("replace local file: {e}")))?;
+    finish_progress();
+
+    let bytes = download.bytes_received();
+    let handle = object.handle.0;
+    let filename = object.filename;
+    let row = GetRow {
+        operation: "get",
+        remote_path: path.raw().to_string(),
+        local_path: local_path.display().to_string(),
+        filename,
+        handle,
+        bytes,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!("downloaded {} ({} bytes)", row.local_path, row.bytes);
+        Ok(())
+    }
+}
+
+async fn verify_remote_matches_local(
+    storage: &Storage,
+    handle: ObjectHandle,
+    local_path: &Path,
+    total_size: u64,
+    verbose: bool,
+) -> Result<(), CliError> {
+    let mut remote = storage
+        .download_stream(handle)
+        .await
+        .map_err(|e| CliError::from_mtp("verify download", e, verbose))?;
+    let mut local = tokio::fs::File::open(local_path)
+        .await
+        .map_err(|e| CliError::new(CliErrorKind::Verify, format!("verify local file: {e}")))?;
+    let mut compared = 0u64;
+
+    while let Some(chunk) = remote.next_chunk().await {
+        let bytes = chunk.map_err(|e| CliError::from_mtp("verify download", e, verbose))?;
+        let mut local_bytes = vec![0; bytes.len()];
+        local
+            .read_exact(&mut local_bytes)
+            .await
+            .map_err(|e| CliError::new(CliErrorKind::Verify, format!("verify local file: {e}")))?;
+        if bytes.as_ref() != local_bytes.as_slice() {
+            return Err(CliError::new(
+                CliErrorKind::Verify,
+                "verification failed: uploaded bytes differ from local file",
+            ));
+        }
+        compared += bytes.len() as u64;
+    }
+
+    if compared != total_size {
+        return Err(CliError::new(
+            CliErrorKind::Verify,
+            "verification failed: uploaded size differs from local file",
+        ));
+    }
+
+    Ok(())
+}
+
+async fn mkdir(cli: &Cli, remote_path: &str) -> Result<(), CliError> {
+    let (_device, storage) = open_storage(cli, true).await?;
+    let path = RemotePath::parse(remote_path)?;
+    if path.is_root() {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "cannot create the storage root",
+        ));
+    }
+
+    let components = path.components();
+    let name = components
+        .last()
+        .expect("non-root path has final component");
+    let parent_path = RemotePath::parse(&parent_path_string(components))?;
+    let parent = match path::resolve_existing(&storage, &parent_path, cli.verbose).await? {
+        ExistingRemote::Root => None,
+        ExistingRemote::Object(object) if object.is_folder() => Some(object.handle),
+        ExistingRemote::Object(_) => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote parent is not a folder",
+            ));
+        }
+    };
+
+    let siblings = storage
+        .list_objects(parent)
+        .await
+        .map_err(|e| CliError::from_mtp("list remote folder", e, cli.verbose))?;
+    if siblings
+        .iter()
+        .any(|object| object.filename == name.as_str())
+    {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "remote object already exists",
+        ));
+    }
+
+    let handle = storage
+        .create_folder(parent, name)
+        .await
+        .map_err(|e| CliError::from_mtp("create remote folder", e, cli.verbose))?;
+    let row = MkdirRow {
+        operation: "mkdir",
+        remote_path: remote_path.to_string(),
+        filename: name.to_string(),
+        handle: handle.0,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!("created folder {} handle={}", row.remote_path, row.handle);
+        Ok(())
+    }
+}
+
+async fn rm(cli: &Cli, remote_path: &str, yes: bool) -> Result<(), CliError> {
+    if !yes {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "refusing to delete without --yes",
+        ));
+    }
+
+    let (_device, storage) = open_storage(cli, true).await?;
+    let path = RemotePath::parse(remote_path)?;
+    let object = match path::resolve_existing(&storage, &path, cli.verbose).await? {
+        ExistingRemote::Root => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "refusing to delete the storage root",
+            ));
+        }
+        ExistingRemote::Object(object) => object,
+    };
+
+    storage
+        .delete(object.handle)
+        .await
+        .map_err(|e| CliError::from_mtp("delete remote object", e, cli.verbose))?;
+    let kind = if object.is_folder() { "folder" } else { "file" };
+    let row = RmRow {
+        operation: "rm",
+        remote_path: remote_path.to_string(),
+        filename: object.filename,
+        handle: object.handle.0,
+        kind,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!("deleted {} handle={}", row.remote_path, row.handle);
+        Ok(())
+    }
+}
+
+async fn rename(cli: &Cli, remote_path: &str, new_name: &str) -> Result<(), CliError> {
+    path::validate_component(new_name)?;
+    let (device, storage) = open_storage(cli, true).await?;
+    ensure_rename_supported(&device)?;
+    let path = RemotePath::parse(remote_path)?;
+    let object = existing_object(&storage, &path, cli.verbose).await?;
+    let old_name = object.filename.clone();
+    ensure_rename_target_available(&storage, &path, object.handle, new_name, cli.verbose).await?;
+
+    storage
+        .rename(object.handle, new_name)
+        .await
+        .map_err(|e| CliError::from_mtp("rename remote object", e, cli.verbose))?;
+
+    let row = RenameRow {
+        operation: "rename",
+        remote_path: remote_path.to_string(),
+        old_name,
+        new_name: new_name.to_string(),
+        handle: object.handle.0,
+        kind: if object.is_folder() { "folder" } else { "file" },
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!(
+            "renamed {} -> {} handle={}",
+            row.old_name, row.new_name, row.handle
+        );
+        Ok(())
+    }
+}
+
+async fn move_remote(
+    cli: &Cli,
+    source_path: &str,
+    destination_path: &str,
+    replace: bool,
+) -> Result<(), CliError> {
+    let (device, storage) = open_storage(cli, true).await?;
+    let source_path = RemotePath::parse(source_path)?;
+    let destination_path = RemotePath::parse(destination_path)?;
+    let source = existing_object(&storage, &source_path, cli.verbose).await?;
+    let source_name = source.filename.clone();
+    let source_kind = if source.is_folder() { "folder" } else { "file" };
+    let target =
+        resolve_object_destination(&storage, &destination_path, &source_name, cli.verbose).await?;
+    let renamed = target.filename != source_name;
+
+    if renamed {
+        ensure_rename_supported(&device)?;
+    }
+    let replaced = target.existing.is_some();
+    if let Some(existing) = &target.existing {
+        ensure_not_same_object(source.handle, existing.handle)?;
+        if !replace {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "destination already exists; pass --replace to delete it first",
+            ));
+        }
+        storage
+            .delete(existing.handle)
+            .await
+            .map_err(|e| CliError::from_mtp("delete existing destination", e, cli.verbose))?;
+    }
+
+    let parent = target.parent.unwrap_or(ObjectHandle::ROOT);
+    storage
+        .move_object(source.handle, parent, None)
+        .await
+        .map_err(|e| CliError::from_mtp("move remote object", e, cli.verbose))?;
+    if renamed {
+        storage
+            .rename(source.handle, &target.filename)
+            .await
+            .map_err(|e| CliError::from_mtp("rename moved object", e, cli.verbose))?;
+    }
+
+    let row = MoveRow {
+        operation: "mv",
+        source_path: source_path.raw().to_string(),
+        destination_path: destination_path.raw().to_string(),
+        filename: target.filename,
+        handle: source.handle.0,
+        kind: source_kind,
+        replaced,
+        renamed,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!(
+            "moved {} -> {} handle={}",
+            row.source_path, row.destination_path, row.handle
+        );
+        Ok(())
+    }
+}
+
+async fn copy_remote(
+    cli: &Cli,
+    source_path: &str,
+    destination_path: &str,
+    replace: bool,
+) -> Result<(), CliError> {
+    let (device, storage) = open_storage(cli, true).await?;
+    let source_path = RemotePath::parse(source_path)?;
+    let destination_path = RemotePath::parse(destination_path)?;
+    let source = existing_object(&storage, &source_path, cli.verbose).await?;
+    let source_name = source.filename.clone();
+    let source_kind = if source.is_folder() { "folder" } else { "file" };
+    let target =
+        resolve_object_destination(&storage, &destination_path, &source_name, cli.verbose).await?;
+    let renamed = target.filename != source_name;
+
+    if renamed {
+        ensure_rename_supported(&device)?;
+    }
+    let replaced = target.existing.is_some();
+    if let Some(existing) = &target.existing {
+        ensure_not_same_object(source.handle, existing.handle)?;
+        if !replace {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "destination already exists; pass --replace to delete it first",
+            ));
+        }
+        storage
+            .delete(existing.handle)
+            .await
+            .map_err(|e| CliError::from_mtp("delete existing destination", e, cli.verbose))?;
+    }
+
+    let parent = target.parent.unwrap_or(ObjectHandle::ROOT);
+    let new_handle = storage
+        .copy_object(source.handle, parent, None)
+        .await
+        .map_err(|e| CliError::from_mtp("copy remote object", e, cli.verbose))?;
+    if renamed {
+        storage
+            .rename(new_handle, &target.filename)
+            .await
+            .map_err(|e| CliError::from_mtp("rename copied object", e, cli.verbose))?;
+    }
+
+    let row = CopyRow {
+        operation: "cp",
+        source_path: source_path.raw().to_string(),
+        destination_path: destination_path.raw().to_string(),
+        filename: target.filename,
+        source_handle: source.handle.0,
+        handle: new_handle.0,
+        kind: source_kind,
+        replaced,
+        renamed,
+    };
+
+    if cli.json {
+        print_json(&row)
+    } else {
+        println!(
+            "copied {} -> {} handle={}",
+            row.source_path, row.destination_path, row.handle
+        );
+        Ok(())
+    }
+}
+
+async fn doctor(cli: &Cli) -> Result<(), CliError> {
+    let devices = MtpDevice::list_devices_with_known(&cli.known)
+        .map_err(|e| CliError::from_mtp("list devices", e, cli.verbose))?;
+    if devices.is_empty() {
+        if cli.json {
+            print_json(&DoctorRow {
+                devices: Vec::new(),
+                opened: None,
+                open_error: None,
+                open_help: None,
+                storages: Vec::new(),
+            })?;
+        } else {
+            println!("devices: none");
+        }
+        return Err(CliError::new(CliErrorKind::NoDevice, "no MTP device found"));
+    }
+    let device_rows: Vec<DeviceRow> = devices.iter().map(DeviceRow::from).collect();
+    if !cli.json {
+        println!("devices: {} visible", devices.len());
+        for device in &devices {
+            println!("  {}", device.display());
+        }
+    }
+
+    let device = match open_selected_device(cli).await {
+        Ok(device) => device,
+        Err(err) => {
+            if cli.json {
+                print_json(&DoctorRow {
+                    devices: device_rows,
+                    opened: None,
+                    open_error: Some(err.to_string()),
+                    open_help: err.help().map(str::to_string),
+                    storages: Vec::new(),
+                })?;
+            }
+            return Err(err);
+        }
+    };
+    let opened = OpenedDeviceRow {
+        manufacturer: device.device_info().manufacturer.clone(),
+        model: device.device_info().model.clone(),
+        serial_number: device.device_info().serial_number.clone(),
+    };
+    if !cli.json {
+        println!("open: ok ({} {})", opened.manufacturer, opened.model);
+    }
+
+    let storages = device
+        .storages()
+        .await
+        .map_err(|e| CliError::from_mtp("list storages", e, cli.verbose))?;
+    let mut storage_rows = Vec::new();
+    if !cli.json {
+        println!("storages: {}", storages.len());
+    }
+    for (index, storage) in storages.iter().enumerate() {
+        if !cli.json {
+            println!(
+                "  [{}] {} free={} access={:?}",
+                index,
+                storage.info().description,
+                storage.info().free_space_bytes,
+                storage.info().access_capability
+            );
+        }
+        let root = storage
+            .list_objects(None)
+            .await
+            .map_err(|e| CliError::from_mtp("list storage root", e, cli.verbose))?;
+        let hints: Vec<String> = [
+            "Download",
+            "Downloads",
+            "Documents",
+            "Music",
+            "Pictures",
+            "Audiobooks",
+            "Podcasts",
+            "GARMIN",
+        ]
+        .into_iter()
+        .filter(|name| {
+            root.iter()
+                .any(|object| object.is_folder() && object.filename == *name)
+        })
+        .map(str::to_string)
+        .collect();
+        if !cli.json {
+            if hints.is_empty() {
+                println!("      writable-folder hints: none found at root");
+            } else {
+                println!("      writable-folder hints: {}", hints.join(", "));
+            }
+        }
+        storage_rows.push(DoctorStorageRow {
+            storage: StorageRow::from_storage(index, storage),
+            root_listed: true,
+            writable_folder_hints: hints,
+        });
+    }
+
+    if cli.json {
+        print_json(&DoctorRow {
+            devices: device_rows,
+            opened: Some(opened),
+            open_error: None,
+            open_help: None,
+            storages: storage_rows,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+async fn open_storage(cli: &Cli, mutating: bool) -> Result<(MtpDevice, Storage), CliError> {
+    let device = open_selected_device(cli).await?;
+    let storages = device
+        .storages()
+        .await
+        .map_err(|e| CliError::from_mtp("list storages", e, cli.verbose))?;
+    if storages.is_empty() {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "device has no storages",
+        ));
+    }
+
+    let storage = if let Some(selection) = &cli.storage {
+        select_storage(storages, selection)?
+    } else if mutating && storages.len() > 1 {
+        return Err(CliError::new(
+            CliErrorKind::AmbiguousSelection,
+            "multiple storages found; pass --storage INDEX_OR_ID for mutating commands",
+        ));
+    } else {
+        storages
+            .into_iter()
+            .next()
+            .expect("empty storages handled above")
+    };
+
+    Ok((device, storage))
+}
+
+async fn open_selected_device(cli: &Cli) -> Result<MtpDevice, CliError> {
+    let builder = MtpDevice::builder()
+        .known_devices(&cli.known)
+        .timeout(Duration::from_secs(cli.timeout));
+
+    if let Some(serial) = &cli.device {
+        return builder
+            .open_by_serial(serial)
+            .await
+            .map_err(|e| CliError::from_mtp("open device", e, cli.verbose));
+    }
+
+    if let Some(location) = cli.location {
+        return builder
+            .open_by_location(location)
+            .await
+            .map_err(|e| CliError::from_mtp("open device", e, cli.verbose));
+    }
+
+    let devices = MtpDevice::list_devices_with_known(&cli.known)
+        .map_err(|e| CliError::from_mtp("list devices", e, cli.verbose))?;
+    match devices.as_slice() {
+        [] => Err(CliError::new(CliErrorKind::NoDevice, "no MTP device found")),
+        [device] => MtpDevice::builder()
+            .known_devices(&cli.known)
+            .timeout(Duration::from_secs(cli.timeout))
+            .open_by_location(device.location_id)
+            .await
+            .map_err(|e| CliError::from_mtp("open device", e, cli.verbose)),
+        _ => Err(CliError::new(
+            CliErrorKind::AmbiguousSelection,
+            "multiple MTP devices found; pass --device SERIAL or --location LOCATION",
+        )),
+    }
+}
+
+fn select_storage(mut storages: Vec<Storage>, selection: &str) -> Result<Storage, CliError> {
+    if let Ok(index) = selection.parse::<usize>() {
+        if index < storages.len() {
+            return Ok(storages.remove(index));
+        }
+    }
+
+    let id = parse_storage_id(selection)?;
+    let index = storages
+        .iter()
+        .position(|storage| storage.id() == StorageId(id))
+        .ok_or_else(|| CliError::new(CliErrorKind::RemotePath, "storage not found"))?;
+    Ok(storages.remove(index))
+}
+
+fn parse_storage_id(selection: &str) -> Result<u32, CliError> {
+    if let Some(hex) = selection
+        .strip_prefix("0x")
+        .or_else(|| selection.strip_prefix("0X"))
+    {
+        return u32::from_str_radix(hex, 16)
+            .map_err(|_| CliError::new(CliErrorKind::RemotePath, "invalid storage ID"));
+    }
+
+    if selection
+        .chars()
+        .any(|c| matches!(c, 'a'..='f' | 'A'..='F'))
+    {
+        return u32::from_str_radix(selection, 16)
+            .map_err(|_| CliError::new(CliErrorKind::RemotePath, "invalid storage ID"));
+    }
+
+    selection
+        .parse::<u32>()
+        .map_err(|_| CliError::new(CliErrorKind::RemotePath, "invalid storage selection"))
+}
+
+async fn folder_parent(
+    storage: &Storage,
+    path: &RemotePath,
+    verbose: bool,
+) -> Result<(Option<ObjectHandle>, String), CliError> {
+    match path::resolve_existing(storage, path, verbose).await? {
+        ExistingRemote::Root => Ok((None, "/".to_string())),
+        ExistingRemote::Object(object) if object.is_folder() => {
+            Ok((Some(object.handle), path.raw().to_string()))
+        }
+        ExistingRemote::Object(_) => Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "remote path is not a folder",
+        )),
+    }
+}
+
+fn parent_path_string(components: &[String]) -> String {
+    if components.len() <= 1 {
+        "/".to_string()
+    } else {
+        format!("/{}", components[..components.len() - 1].join("/"))
+    }
+}
+
+async fn existing_object(
+    storage: &Storage,
+    path: &RemotePath,
+    verbose: bool,
+) -> Result<ObjectInfo, CliError> {
+    match path::resolve_existing(storage, path, verbose).await? {
+        ExistingRemote::Root => Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "remote path cannot be the storage root",
+        )),
+        ExistingRemote::Object(object) => Ok(object),
+    }
+}
+
+async fn resolve_object_destination(
+    storage: &Storage,
+    destination_path: &RemotePath,
+    source_filename: &str,
+    verbose: bool,
+) -> Result<path::UploadTarget, CliError> {
+    path::resolve_upload_target(storage, destination_path, source_filename, verbose).await
+}
+
+fn ensure_rename_supported(device: &MtpDevice) -> Result<(), CliError> {
+    if device.supports_rename() {
+        Ok(())
+    } else {
+        Err(CliError::new(
+            CliErrorKind::Transfer,
+            "device does not support rename; cannot change the destination filename",
+        ))
+    }
+}
+
+async fn ensure_rename_target_available(
+    storage: &Storage,
+    source_path: &RemotePath,
+    source_handle: ObjectHandle,
+    new_name: &str,
+    verbose: bool,
+) -> Result<(), CliError> {
+    let parent_path = RemotePath::parse(&parent_path_string(source_path.components()))?;
+    let parent = match path::resolve_existing(storage, &parent_path, verbose).await? {
+        ExistingRemote::Root => None,
+        ExistingRemote::Object(object) if object.is_folder() => Some(object.handle),
+        ExistingRemote::Object(_) => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote parent is not a folder",
+            ));
+        }
+    };
+    let siblings = storage
+        .list_objects(parent)
+        .await
+        .map_err(|e| CliError::from_mtp("list remote parent", e, verbose))?;
+
+    if siblings
+        .iter()
+        .any(|object| object.filename == new_name && object.handle != source_handle)
+    {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "destination name already exists",
+        ));
+    }
+
+    Ok(())
+}
+
+fn ensure_not_same_object(source: ObjectHandle, destination: ObjectHandle) -> Result<(), CliError> {
+    if source == destination {
+        Err(CliError::new(
+            CliErrorKind::RemotePath,
+            "source and destination are the same remote object",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn temp_download_path(destination: &Path) -> PathBuf {
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("download");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    parent.join(format!(".{name}.mtp-rs-{nonce}-{}.tmp", std::process::id()))
+}
+
+fn file_stream(
+    file: tokio::fs::File,
+) -> Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>> {
+    Box::pin(futures::stream::unfold(file, |mut file| async move {
+        let mut buf = vec![0; CHUNK_SIZE];
+        match file.read(&mut buf).await {
+            Ok(0) => None,
+            Ok(n) => {
+                buf.truncate(n);
+                Some((Ok(Bytes::from(buf)), file))
+            }
+            Err(e) => Some((Err(e), file)),
+        }
+    }))
+}
+
+fn print_progress(label: &str, done: u64, total: u64, last_percent: &mut u64) {
+    let percent = done.saturating_mul(100).checked_div(total).unwrap_or(100);
+    if percent != *last_percent {
+        eprint!("\r{}: {}% ({}/{})", label, percent, done, total);
+        let _ = std::io::stderr().flush();
+        *last_percent = percent;
+    }
+}
+
+fn finish_progress() {
+    eprintln!();
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), CliError> {
+    serde_json::to_writer_pretty(std::io::stdout(), value)
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("write JSON: {e}")))?;
+    println!();
+    std::io::stdout()
+        .flush()
+        .map_err(|e| CliError::new(CliErrorKind::Other, format!("flush JSON: {e}")))?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct DeviceRow {
+    vendor_id: u16,
+    product_id: u16,
+    manufacturer: Option<String>,
+    product: Option<String>,
+    serial_number: Option<String>,
+    location_id: u64,
+    location: String,
+    speed: Option<String>,
+    match_reason: String,
+}
+
+impl From<&MtpDeviceInfo> for DeviceRow {
+    fn from(info: &MtpDeviceInfo) -> Self {
+        Self {
+            vendor_id: info.vendor_id,
+            product_id: info.product_id,
+            manufacturer: info.manufacturer.clone(),
+            product: info.product.clone(),
+            serial_number: info.serial_number.clone(),
+            location_id: info.location_id,
+            location: format!("{:08x}", info.location_id),
+            speed: info.speed.map(|speed| format!("{speed:?}")),
+            match_reason: info.match_reason.as_str().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct InfoRow {
+    manufacturer: String,
+    model: String,
+    serial_number: String,
+    device_version: String,
+    supports_rename: bool,
+    storages: Vec<StorageRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageRow {
+    index: usize,
+    id: String,
+    id_raw: u32,
+    description: String,
+    volume_identifier: String,
+    max_capacity: u64,
+    free_space_bytes: u64,
+    access_capability: String,
+    storage_type: String,
+    filesystem_type: String,
+}
+
+impl StorageRow {
+    fn from_storage(index: usize, storage: &Storage) -> Self {
+        Self {
+            index,
+            id: format!("{:08x}", storage.id().0),
+            id_raw: storage.id().0,
+            description: storage.info().description.clone(),
+            volume_identifier: storage.info().volume_identifier.clone(),
+            max_capacity: storage.info().max_capacity,
+            free_space_bytes: storage.info().free_space_bytes,
+            access_capability: format!("{:?}", storage.info().access_capability),
+            storage_type: format!("{:?}", storage.info().storage_type),
+            filesystem_type: format!("{:?}", storage.info().filesystem_type),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct LsRow {
+    path: String,
+    recursive: bool,
+    objects: Vec<ObjectRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct PutRow {
+    operation: &'static str,
+    local_path: String,
+    remote_path: String,
+    filename: String,
+    handle: u32,
+    bytes: u64,
+    replaced: bool,
+    verified: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct GetRow {
+    operation: &'static str,
+    remote_path: String,
+    local_path: String,
+    filename: String,
+    handle: u32,
+    bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct MkdirRow {
+    operation: &'static str,
+    remote_path: String,
+    filename: String,
+    handle: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct RmRow {
+    operation: &'static str,
+    remote_path: String,
+    filename: String,
+    handle: u32,
+    kind: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct RenameRow {
+    operation: &'static str,
+    remote_path: String,
+    old_name: String,
+    new_name: String,
+    handle: u32,
+    kind: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct MoveRow {
+    operation: &'static str,
+    source_path: String,
+    destination_path: String,
+    filename: String,
+    handle: u32,
+    kind: &'static str,
+    replaced: bool,
+    renamed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CopyRow {
+    operation: &'static str,
+    source_path: String,
+    destination_path: String,
+    filename: String,
+    source_handle: u32,
+    handle: u32,
+    kind: &'static str,
+    replaced: bool,
+    renamed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorRow {
+    devices: Vec<DeviceRow>,
+    opened: Option<OpenedDeviceRow>,
+    open_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    open_help: Option<String>,
+    storages: Vec<DoctorStorageRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenedDeviceRow {
+    manufacturer: String,
+    model: String,
+    serial_number: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorStorageRow {
+    storage: StorageRow,
+    root_listed: bool,
+    writable_folder_hints: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ObjectRow {
+    handle: u32,
+    storage_id: u32,
+    parent: u32,
+    filename: String,
+    kind: String,
+    size: u64,
+    format: String,
+}
+
+impl From<&ObjectInfo> for ObjectRow {
+    fn from(info: &ObjectInfo) -> Self {
+        Self {
+            handle: info.handle.0,
+            storage_id: info.storage_id.0,
+            parent: info.parent.0,
+            filename: info.filename.clone(),
+            kind: if info.is_folder() { "folder" } else { "file" }.to_string(),
+            size: info.size,
+            format: format!("{:?}", info.format),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn command_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn parent_path_for_one_component_is_root() {
+        assert_eq!(parent_path_string(&["Music".to_string()]), "/");
+    }
+
+    #[test]
+    fn parent_path_for_nested_component_is_parent() {
+        assert_eq!(
+            parent_path_string(&["GARMIN".to_string(), "APPS".to_string()]),
+            "/GARMIN"
+        );
+    }
+
+    #[cfg(feature = "virtual-device")]
+    struct VirtualCliFixture {
+        _tempdir: tempfile::TempDir,
+        serial: String,
+        location_id: u64,
+    }
+
+    #[cfg(feature = "virtual-device")]
+    impl Drop for VirtualCliFixture {
+        fn drop(&mut self) {
+            mtp_rs::unregister_virtual_device(self.location_id);
+        }
+    }
+
+    #[cfg(feature = "virtual-device")]
+    fn virtual_cli_fixture() -> VirtualCliFixture {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backing_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&backing_dir).unwrap();
+        let serial = format!(
+            "cli-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let config = mtp_rs::VirtualDeviceConfig {
+            manufacturer: "TestCorp".into(),
+            model: "CLI Device".into(),
+            serial: serial.clone(),
+            storages: vec![mtp_rs::VirtualStorageConfig {
+                description: "Internal Storage".into(),
+                capacity: 64 * 1024 * 1024,
+                backing_dir,
+                read_only: false,
+            }],
+            supports_rename: true,
+            event_poll_interval: Duration::ZERO,
+            watch_backing_dirs: false,
+        };
+        let info = mtp_rs::register_virtual_device(&config);
+
+        VirtualCliFixture {
+            _tempdir: tempdir,
+            serial,
+            location_id: info.location_id,
+        }
+    }
+
+    #[cfg(feature = "virtual-device")]
+    fn test_cli(serial: &str, json: bool) -> Cli {
+        Cli {
+            device: Some(serial.to_string()),
+            location: None,
+            storage: None,
+            known: Vec::new(),
+            timeout: 30,
+            json,
+            verbose: false,
+            command: Command::Doctor,
+        }
+    }
+
+    #[cfg(feature = "virtual-device")]
+    #[tokio::test]
+    async fn virtual_device_cli_file_lifecycle() {
+        let fixture = virtual_cli_fixture();
+        let cli = test_cli(&fixture.serial, true);
+        let local = fixture._tempdir.path().join("local.txt");
+        let downloaded = fixture._tempdir.path().join("downloaded.txt");
+        let copied = fixture._tempdir.path().join("copied.txt");
+        let moved = fixture._tempdir.path().join("moved.txt");
+
+        devices(&cli).unwrap();
+        info(&cli).await.unwrap();
+        ls(&cli, "/", false).await.unwrap();
+        mkdir(&cli, "/Upload").await.unwrap();
+
+        tokio::fs::write(&local, b"hello virtual cli")
+            .await
+            .unwrap();
+        put(&cli, &local, "/Upload/remote.txt", false, true)
+            .await
+            .unwrap();
+        ls(&cli, "/Upload", false).await.unwrap();
+        get(&cli, "/Upload/remote.txt", &downloaded, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&downloaded).await.unwrap(),
+            "hello virtual cli"
+        );
+
+        tokio::fs::write(&local, b"updated virtual cli")
+            .await
+            .unwrap();
+        put(&cli, &local, "/Upload/remote.txt", true, true)
+            .await
+            .unwrap();
+        get(&cli, "/Upload/remote.txt", &downloaded, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&downloaded).await.unwrap(),
+            "updated virtual cli"
+        );
+
+        rename(&cli, "/Upload/remote.txt", "renamed.txt")
+            .await
+            .unwrap();
+        mkdir(&cli, "/Archive").await.unwrap();
+        copy_remote(&cli, "/Upload/renamed.txt", "/Archive/copied.txt", false)
+            .await
+            .unwrap();
+        get(&cli, "/Archive/copied.txt", &copied, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&copied).await.unwrap(),
+            "updated virtual cli"
+        );
+
+        move_remote(&cli, "/Archive/copied.txt", "/Upload/moved.txt", false)
+            .await
+            .unwrap();
+        get(&cli, "/Upload/moved.txt", &moved, false).await.unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&moved).await.unwrap(),
+            "updated virtual cli"
+        );
+        rm(&cli, "/Upload/moved.txt", true).await.unwrap();
+        assert!(get(&cli, "/Upload/moved.txt", &moved, true).await.is_err());
+    }
+}

--- a/src/cli/path.rs
+++ b/src/cli/path.rs
@@ -1,0 +1,239 @@
+use super::error::{CliError, CliErrorKind};
+use mtp_rs::ptp::ObjectInfo;
+use mtp_rs::{ObjectHandle, Storage};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePath {
+    raw: String,
+    components: Vec<String>,
+    trailing_slash: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum ExistingRemote {
+    Root,
+    Object(ObjectInfo),
+}
+
+#[derive(Debug, Clone)]
+pub struct UploadTarget {
+    pub parent: Option<ObjectHandle>,
+    pub filename: String,
+    pub existing: Option<ObjectInfo>,
+}
+
+impl RemotePath {
+    pub fn parse(path: &str) -> Result<Self, CliError> {
+        if path.is_empty() || !path.starts_with('/') {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote path must be absolute, for example /Music/song.mp3",
+            ));
+        }
+
+        let trailing_slash = path != "/" && path.ends_with('/');
+        let mut components = Vec::new();
+        for component in path.split('/').filter(|part| !part.is_empty()) {
+            validate_component(component)?;
+            components.push(component.to_string());
+        }
+
+        Ok(Self {
+            raw: path.to_string(),
+            components,
+            trailing_slash,
+        })
+    }
+
+    #[must_use]
+    pub fn is_root(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    #[must_use]
+    pub fn components(&self) -> &[String] {
+        &self.components
+    }
+
+    #[must_use]
+    pub fn trailing_slash(&self) -> bool {
+        self.trailing_slash
+    }
+}
+
+pub fn validate_component(component: &str) -> Result<(), CliError> {
+    if component.is_empty() || component == "." || component == ".." {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            format!("invalid remote path component '{component}'"),
+        ));
+    }
+
+    if component.contains('/') || component.contains('\\') || component.contains('\0') {
+        return Err(CliError::new(
+            CliErrorKind::RemotePath,
+            format!("invalid remote filename '{component}'"),
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn resolve_existing(
+    storage: &Storage,
+    path: &RemotePath,
+    verbose: bool,
+) -> Result<ExistingRemote, CliError> {
+    if path.is_root() {
+        return Ok(ExistingRemote::Root);
+    }
+
+    let mut parent = None;
+    let mut found = None;
+    for (index, component) in path.components().iter().enumerate() {
+        let objects = storage
+            .list_objects(parent)
+            .await
+            .map_err(|e| CliError::from_mtp("list remote folder", e, verbose))?;
+        let object = objects
+            .into_iter()
+            .find(|object| object.filename == component.as_str())
+            .ok_or_else(|| {
+                CliError::new(
+                    CliErrorKind::RemotePath,
+                    format!("remote path not found: {}", path.raw()),
+                )
+            })?;
+
+        let is_last = index + 1 == path.components().len();
+        if !is_last && !object.is_folder() {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                format!("remote parent is not a folder: {}", object.filename),
+            ));
+        }
+
+        parent = Some(object.handle);
+        found = Some(object);
+    }
+
+    Ok(ExistingRemote::Object(
+        found.expect("non-root path has an object"),
+    ))
+}
+
+pub async fn resolve_upload_target(
+    storage: &Storage,
+    remote_path: &RemotePath,
+    local_filename: &str,
+    verbose: bool,
+) -> Result<UploadTarget, CliError> {
+    if remote_path.is_root() {
+        return Ok(UploadTarget {
+            parent: None,
+            filename: local_filename.to_string(),
+            existing: None,
+        });
+    }
+
+    let mut components = remote_path.components().to_vec();
+    let explicit_folder = remote_path.trailing_slash();
+    let final_name = if explicit_folder {
+        local_filename.to_string()
+    } else {
+        components.pop().expect("non-root path has final component")
+    };
+    validate_component(&final_name)?;
+
+    let parent_path = RemotePath {
+        raw: parent_raw_from_components(&components),
+        components,
+        trailing_slash: false,
+    };
+    let parent = match resolve_existing(storage, &parent_path, verbose).await? {
+        ExistingRemote::Root => None,
+        ExistingRemote::Object(object) if object.is_folder() => Some(object.handle),
+        ExistingRemote::Object(_) => {
+            return Err(CliError::new(
+                CliErrorKind::RemotePath,
+                "remote parent is not a folder",
+            ));
+        }
+    };
+
+    let objects = storage
+        .list_objects(parent)
+        .await
+        .map_err(|e| CliError::from_mtp("list remote folder", e, verbose))?;
+    if let Some(existing_folder) = objects
+        .iter()
+        .find(|object| object.filename == final_name.as_str() && object.is_folder())
+    {
+        return Ok(UploadTarget {
+            parent: Some(existing_folder.handle),
+            filename: local_filename.to_string(),
+            existing: None,
+        });
+    }
+
+    let existing = objects
+        .into_iter()
+        .find(|object| object.filename == final_name.as_str() && object.is_file());
+
+    Ok(UploadTarget {
+        parent,
+        filename: final_name,
+        existing,
+    })
+}
+
+fn parent_raw_from_components(components: &[String]) -> String {
+    if components.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", components.join("/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_root() {
+        let path = RemotePath::parse("/").unwrap();
+        assert!(path.is_root());
+        assert!(!path.trailing_slash());
+    }
+
+    #[test]
+    fn rejects_relative_paths() {
+        assert!(RemotePath::parse("Music/song.mp3").is_err());
+    }
+
+    #[test]
+    fn tracks_trailing_slash_destination() {
+        let path = RemotePath::parse("/Music/").unwrap();
+        assert_eq!(path.components(), vec!["Music".to_string()].as_slice());
+        assert!(path.trailing_slash());
+    }
+
+    #[test]
+    fn rejects_invalid_components() {
+        assert!(RemotePath::parse("/../x").is_err());
+        assert!(RemotePath::parse("/bad\\name").is_err());
+        assert!(RemotePath::parse("/bad\0name").is_err());
+    }
+
+    #[test]
+    fn validates_upload_filename() {
+        assert!(validate_component("app.prg").is_ok());
+        assert!(validate_component("../app.prg").is_err());
+        assert!(validate_component("bad\\app.prg").is_err());
+    }
+}

--- a/src/mtp/device.rs
+++ b/src/mtp/device.rs
@@ -127,6 +127,7 @@ impl MtpDevice {
                 serial_number: d.serial_number,
                 location_id: d.location_id,
                 speed: d.speed,
+                match_reason: d.match_reason,
             })
             .collect();
 
@@ -366,6 +367,9 @@ pub struct MtpDeviceInfo {
     ///
     /// `None` if the OS doesn't report it for this device.
     pub speed: Option<crate::transport::UsbSpeed>,
+
+    /// Why this USB device was classified as an MTP candidate.
+    pub match_reason: crate::transport::MtpMatchReason,
 }
 
 impl MtpDeviceInfo {
@@ -660,6 +664,7 @@ mod tests {
             serial_number: Some("ABC123".to_string()),
             location_id: 0x00200000,
             speed: None,
+            match_reason: crate::transport::MtpMatchReason::StandardClass,
         };
         let display = with_serial.display();
         assert!(display.contains("Samsung") && display.contains("Galaxy S24"));

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,7 +7,7 @@ pub mod nusb;
 #[cfg(feature = "virtual-device")]
 pub mod virtual_device;
 
-pub use self::nusb::{NusbTransport, UsbDeviceInfo, UsbSpeed};
+pub use self::nusb::{MtpMatchReason, NusbTransport, UsbDeviceInfo, UsbSpeed};
 
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/src/transport/nusb.rs
+++ b/src/transport/nusb.rs
@@ -61,6 +61,32 @@ impl UsbSpeed {
     }
 }
 
+/// Why a USB device was classified as an MTP candidate.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum MtpMatchReason {
+    /// Device or interface class/subclass/protocol matched Still Image / MTP.
+    StandardClass,
+    /// The OS-published interface string identifies the interface as MTP.
+    InterfaceString,
+    /// Caller supplied the VID/PID through `known` devices.
+    KnownVidPid,
+    /// The opened configuration descriptor has the MTP endpoint layout.
+    OpenedDescriptorScan,
+}
+
+impl MtpMatchReason {
+    /// Stable snake_case identifier for machine-readable output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::StandardClass => "standard_class",
+            Self::InterfaceString => "interface_string",
+            Self::KnownVidPid => "known_vid_pid",
+            Self::OpenedDescriptorScan => "opened_descriptor_scan",
+        }
+    }
+}
+
 /// USB device information with topology-based location ID.
 ///
 /// Marked `#[non_exhaustive]` so future field additions don't break consumers
@@ -84,6 +110,8 @@ pub struct UsbDeviceInfo {
     /// Negotiated USB link speed (slowest of host port, cable, device).
     /// `None` if the OS doesn't report it for this device.
     pub speed: Option<UsbSpeed>,
+    /// Why this device was classified as an MTP candidate.
+    pub match_reason: MtpMatchReason,
     /// Reference to the underlying nusb device info for opening
     nusb_info: nusb::DeviceInfo,
 }
@@ -129,11 +157,11 @@ impl NusbTransport {
         let devices = nusb::list_devices()
             .wait()
             .map_err(crate::Error::Usb)?
-            .filter(|dev| Self::is_mtp_device(dev, known))
-            .map(|dev| {
+            .filter_map(|dev| {
+                let match_reason = Self::mtp_match_reason(&dev, known)?;
                 let location_id = location_id_from_topology(&dev);
                 let speed = dev.speed().and_then(UsbSpeed::from_nusb);
-                UsbDeviceInfo {
+                Some(UsbDeviceInfo {
                     vendor_id: dev.vendor_id(),
                     product_id: dev.product_id(),
                     manufacturer: dev.manufacturer_string().map(String::from),
@@ -141,8 +169,9 @@ impl NusbTransport {
                     serial_number: dev.serial_number().map(String::from),
                     location_id,
                     speed,
+                    match_reason,
                     nusb_info: dev,
-                }
+                })
             })
             .collect();
         Ok(devices)
@@ -154,30 +183,35 @@ impl NusbTransport {
     /// an interface with the MTP endpoint layout, or matches one of the
     /// caller-provided VID/PID pairs (used for devices with non-standard USB
     /// descriptors that still speak MTP).
-    fn is_mtp_device(dev: &nusb::DeviceInfo, known: &[(u16, u16)]) -> bool {
+    fn mtp_match_reason(dev: &nusb::DeviceInfo, known: &[(u16, u16)]) -> Option<MtpMatchReason> {
         // Fast path: caller-supplied known devices that may use non-standard descriptors.
         if known
             .iter()
             .any(|&(v, p)| v == dev.vendor_id() && p == dev.product_id())
         {
-            return true;
+            return Some(MtpMatchReason::KnownVidPid);
         }
 
         // Check device class/subclass/protocol at device level.
         if Self::is_mtp_class(dev.class(), dev.subclass(), dev.protocol()) {
-            return true;
+            return Some(MtpMatchReason::StandardClass);
         }
 
         // Many devices are composite (class 0) or vendor-specific (class 0xFF)
         // with MTP on one interface. Only inspect these further.
         if dev.class() != 0 && dev.class() != MTP_CLASS_VENDOR {
-            return false;
+            return None;
         }
 
         // Check interface-level class info available from DeviceInfo without opening.
         for intf in dev.interfaces() {
-            if Self::is_mtp_class(intf.class(), intf.subclass(), intf.protocol()) {
-                return true;
+            if let Some(reason) = Self::mtp_summary_match_reason(
+                intf.class(),
+                intf.subclass(),
+                intf.protocol(),
+                intf.interface_string(),
+            ) {
+                return Some(reason);
             }
         }
 
@@ -189,14 +223,29 @@ impl NusbTransport {
                 for interface in config.interfaces() {
                     if let Some(alt) = interface.alt_settings().next() {
                         if Self::is_mtp_interface(&alt) {
-                            return true;
+                            return Some(MtpMatchReason::OpenedDescriptorScan);
                         }
                     }
                 }
             }
         }
 
-        false
+        None
+    }
+
+    fn mtp_summary_match_reason(
+        class: u8,
+        subclass: u8,
+        protocol: u8,
+        interface_string: Option<&str>,
+    ) -> Option<MtpMatchReason> {
+        if Self::is_mtp_class(class, subclass, protocol) {
+            return Some(MtpMatchReason::StandardClass);
+        }
+        if interface_string.is_some_and(|s| s.trim().eq_ignore_ascii_case("MTP")) {
+            return Some(MtpMatchReason::InterfaceString);
+        }
+        None
     }
 
     /// Check if class/subclass/protocol match standard MTP identifiers.
@@ -765,6 +814,45 @@ mod tests {
         for (a, b) in tiers.iter().zip(tiers.iter().skip(1)) {
             assert_ne!(a, b);
         }
+    }
+
+    #[test]
+    fn summary_match_accepts_garmin_style_mtp_interface_string() {
+        assert_eq!(
+            NusbTransport::mtp_summary_match_reason(0xff, 0xff, 0x00, Some("MTP")),
+            Some(MtpMatchReason::InterfaceString)
+        );
+    }
+
+    #[test]
+    fn summary_match_rejects_vendor_specific_without_mtp_string() {
+        assert_eq!(
+            NusbTransport::mtp_summary_match_reason(0xff, 0xff, 0x00, None),
+            None
+        );
+        assert_eq!(
+            NusbTransport::mtp_summary_match_reason(0xff, 0xff, 0x00, Some("Vendor")),
+            None
+        );
+    }
+
+    #[test]
+    fn summary_match_accepts_standard_class_before_interface_string() {
+        assert_eq!(
+            NusbTransport::mtp_summary_match_reason(0x06, 0x01, 0x01, Some("Camera")),
+            Some(MtpMatchReason::StandardClass)
+        );
+    }
+
+    #[test]
+    fn match_reason_as_str_uses_stable_snake_case_values() {
+        assert_eq!(MtpMatchReason::StandardClass.as_str(), "standard_class");
+        assert_eq!(MtpMatchReason::InterfaceString.as_str(), "interface_string");
+        assert_eq!(MtpMatchReason::KnownVidPid.as_str(), "known_vid_pid");
+        assert_eq!(
+            MtpMatchReason::OpenedDescriptorScan.as_str(),
+            "opened_descriptor_scan"
+        );
     }
 
     #[test]

--- a/src/transport/virtual_device/mod.rs
+++ b/src/transport/virtual_device/mod.rs
@@ -78,7 +78,7 @@ pub struct VirtualTransport {
     /// Serial number, used to unregister from the active-states registry on drop.
     serial: String,
     /// Filesystem watcher. Stops watching when dropped.
-    _watcher: Option<notify::RecommendedWatcher>,
+    _watcher: Option<notify::PollWatcher>,
 }
 
 impl VirtualTransport {

--- a/src/transport/virtual_device/registry.rs
+++ b/src/transport/virtual_device/registry.rs
@@ -55,6 +55,7 @@ pub fn register_virtual_device(config: &VirtualDeviceConfig) -> MtpDeviceInfo {
         serial_number: Some(config.serial.clone()),
         location_id,
         speed: None,
+        match_reason: crate::transport::MtpMatchReason::KnownVidPid,
     };
 
     reg.devices.push(VirtualRegistration {

--- a/src/transport/virtual_device/watcher.rs
+++ b/src/transport/virtual_device/watcher.rs
@@ -30,7 +30,7 @@
 use super::builders::build_event;
 use super::state::VirtualDeviceState;
 use crate::ptp::{EventCode, ObjectHandle, StorageId};
-use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, EventKind, PollWatcher, RecursiveMode, Watcher};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -43,7 +43,7 @@ type StorageMap = Vec<(PathBuf, StorageId)>;
 /// The watcher pushes events into `state.event_queue` via the shared mutex.
 pub(super) fn start_fs_watcher(
     state: &std::sync::Arc<Mutex<VirtualDeviceState>>,
-) -> Option<RecommendedWatcher> {
+) -> Option<PollWatcher> {
     let state_clone = std::sync::Arc::clone(state);
 
     // Build a map of backing_dir → storage_id for resolving events.
@@ -62,7 +62,7 @@ pub(super) fn start_fs_watcher(
             .collect()
     };
 
-    let mut watcher = RecommendedWatcher::new(
+    let mut watcher = PollWatcher::new(
         move |res: Result<notify::Event, notify::Error>| {
             let event = match res {
                 Ok(e) => e,
@@ -71,14 +71,16 @@ pub(super) fn start_fs_watcher(
 
             handle_notify_event(&state_clone, &storage_map, event);
         },
-        Config::default(),
+        Config::default().with_poll_interval(std::time::Duration::from_millis(50)),
     )
     .ok()?;
 
     // Watch all backing directories recursively.
     let state_lock = state.lock().unwrap();
     for storage in &state_lock.storages {
-        let _ = watcher.watch(&storage.config.backing_dir, RecursiveMode::Recursive);
+        watcher
+            .watch(&storage.config.backing_dir, RecursiveMode::Recursive)
+            .ok()?;
     }
     drop(state_lock);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,149 @@
+#![cfg(all(feature = "cli", feature = "virtual-device"))]
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SERIAL: &str = "cli-process-test";
+
+struct CliFixture {
+    _tempdir: tempfile::TempDir,
+    backing_dir: PathBuf,
+}
+
+impl CliFixture {
+    fn new() -> Self {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backing_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&backing_dir).unwrap();
+        Self {
+            _tempdir: tempdir,
+            backing_dir,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_mtp-rs"));
+        command
+            .env("__MTP_RS_TEST_VIRTUAL_ROOT", &self.backing_dir)
+            .env("__MTP_RS_TEST_VIRTUAL_SERIAL", SERIAL);
+        command
+    }
+
+    fn run_json(&self, args: &[&str]) -> Value {
+        let output = self.output(args);
+        assert!(
+            output.status.success(),
+            "command failed: {args:?}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+            panic!(
+                "stdout is not valid JSON: {err}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
+
+    fn output(&self, args: &[&str]) -> Output {
+        self.command().args(args).output().unwrap()
+    }
+}
+
+#[test]
+fn devices_json_lists_virtual_device() {
+    let fixture = CliFixture::new();
+
+    let value = fixture.run_json(&["--json", "devices"]);
+    let devices = value.as_array().expect("devices output is an array");
+    let device = devices
+        .iter()
+        .find(|device| device["serial_number"] == SERIAL)
+        .expect("virtual device is listed");
+
+    assert_eq!(device["manufacturer"], "TestCorp");
+    assert_eq!(device["product"], "CLI Test Device");
+    assert_eq!(device["match_reason"], "known_vid_pid");
+}
+
+#[test]
+fn file_lifecycle_through_cli_binary_emits_json() {
+    let fixture = CliFixture::new();
+    let local = fixture._tempdir.path().join("local.txt");
+    let downloaded = fixture._tempdir.path().join("downloaded.txt");
+    std::fs::write(&local, b"hello from cli process").unwrap();
+
+    let info = fixture.run_json(&["--json", "--device", SERIAL, "info"]);
+    assert_eq!(info["serial_number"], SERIAL);
+    assert_eq!(info["storages"][0]["description"], "Internal Storage");
+
+    let mkdir = fixture.run_json(&["--json", "--device", SERIAL, "mkdir", "/Upload"]);
+    assert_eq!(mkdir["operation"], "mkdir");
+    assert_eq!(mkdir["remote_path"], "/Upload");
+
+    let put = fixture.run_json(&[
+        "--json",
+        "--device",
+        SERIAL,
+        "put",
+        path_str(&local),
+        "/Upload/remote.txt",
+        "--verify",
+    ]);
+    assert_eq!(put["operation"], "put");
+    assert_eq!(put["remote_path"], "/Upload/remote.txt");
+    assert_eq!(put["verified"], true);
+
+    let listing = fixture.run_json(&["--json", "--device", SERIAL, "ls", "/Upload"]);
+    let objects = listing["objects"].as_array().expect("objects is an array");
+    assert!(objects
+        .iter()
+        .any(|object| object["filename"] == "remote.txt"));
+
+    let get = fixture.run_json(&[
+        "--json",
+        "--device",
+        SERIAL,
+        "get",
+        "/Upload/remote.txt",
+        path_str(&downloaded),
+    ]);
+    assert_eq!(get["operation"], "get");
+    assert_eq!(
+        std::fs::read_to_string(&downloaded).unwrap(),
+        "hello from cli process"
+    );
+
+    let rm = fixture.run_json(&[
+        "--json",
+        "--device",
+        SERIAL,
+        "rm",
+        "/Upload/remote.txt",
+        "--yes",
+    ]);
+    assert_eq!(rm["operation"], "rm");
+    assert_eq!(rm["remote_path"], "/Upload/remote.txt");
+}
+
+#[test]
+fn parser_errors_cross_process_boundary() {
+    let fixture = CliFixture::new();
+
+    let output = fixture.output(&["--device", "one", "--location", "0x1", "info"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("cannot be used with")
+            || String::from_utf8_lossy(&output.stderr).contains("unexpected argument")
+    );
+
+    let output = fixture.output(&["--known", "not-a-vid-pid", "devices"]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("expected VID:PID"));
+}
+
+fn path_str(path: &Path) -> &str {
+    path.to_str().expect("test path is valid UTF-8")
+}


### PR DESCRIPTION
## Summary

This PR adds a `mtp-rs` CLI for MTP file transfer.

## Problem
On macOS there is no stable automation-friendly MTP CLI that works well for development workflows, including agentic. Existing tools are unstable, mostly GUI-first, platform-specific, or depend on libmtp/libusb.

`mtp-rs` already has the right pure-Rust transport and high-level MTP APIs, so this PR exposes them through a small CLI.

## What changed

- Added `mtp-rs` binary behind the optional `cli` feature.
- Added common file-transfer commands: `devices`, `info`, `ls`, `put`, `get`, `mkdir`, `rm`, `rename`, `mv`, `cp`, and `doctor`.
- Added JSON output for automation.
- Improved discovery for Garmin-style MTP devices that expose a vendor-specific interface named `MTP` (checked on Venu 2/2S).
- Added virtual-device based CLI tests.
- Added CLI documentation in `docs/cli.md`.

Note:
* Virtual device tests were flaky on my MacBook machine, so they were switched to `PollWatcher` (41e5dc1cced5287972a39ef150b587527a351c0b)

## Distribution

To check the CLI locally we could use the following command:

```
cargo install --path . --features cli --locked
```

But the ideal distribution path for the CLI is a Homebrew tap which need to be done separately (e.g. https://github.com/dtretyakov/mtp-rs/commit/7b06ce6624f602fe4c3d1e448b5f9d94085d574d)