### PR TITLE
mtp: preserve valid siblings after per-object GeneralError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Entries are grouped by release. Each entry tags which crate it applies to with *
 
 ## [Unreleased]
 
+### Fixed
+
+- **[lib] One rejected `GetObjectInfo` no longer hides every valid sibling in a directory.** After a device has returned the handle list, an explicit `GeneralError` response for one handle is now reported as a skipped-object diagnostic while collection continues. `Storage::list_objects_detailed` returns both the valid objects and those diagnostics; the existing streaming API still yields the per-object error directly. Transport, session, cancellation, malformed-data, stale-handle, and all other failures remain fatal.
+
 ## [0.29.0] - 2026-07-21
 
 Library `0.29.0`, CLI `0.7.4`. Recovering a wedged device stops being a CLI-only trick: consumers get the session-less reset, the error that says a reset happened now reaches them, and the diagnostic that captures the evidence finally runs on Android.

--- a/crates/mtp-rs/src/lib.rs
+++ b/crates/mtp-rs/src/lib.rs
@@ -57,9 +57,9 @@ pub use mtp::{Error, UploadError};
 // Backend-neutral high-level types (the default vocabulary for `mtp::`).
 pub use mtp::{
     Backend, ByteRange, Capabilities, DateTime, DeviceEvent, DeviceInfo, FileDownload, MtpDevice,
-    MtpDeviceBuilder, NewObjectInfo, ObjectFormat, ObjectHandle, ObjectInfo, ObjectListing,
-    Progress, Storage, StorageId, StorageInfo, WindowedDownload, DEFAULT_CANCEL_TIMEOUT,
-    DEFAULT_DOWNLOAD_WINDOW,
+    MtpDeviceBuilder, NewObjectInfo, ObjectCollection, ObjectFormat, ObjectHandle, ObjectInfo,
+    ObjectListing, Progress, SkippedObject, Storage, StorageId, StorageInfo, WindowedDownload,
+    DEFAULT_CANCEL_TIMEOUT, DEFAULT_DOWNLOAD_WINDOW,
 };
 
 // Low-level PTP escape hatch for cameras / protocol work. These keep their PTP-specific

--- a/crates/mtp-rs/src/mtp/backend/mod.rs
+++ b/crates/mtp-rs/src/mtp/backend/mod.rs
@@ -109,8 +109,46 @@ pub(crate) struct BackendDownload {
     pub(crate) body: Box<dyn DownloadBody>,
 }
 
+/// Whether a per-handle metadata error invalidates the whole collection or can
+/// be reported while sibling enumeration continues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ListingErrorDisposition {
+    Fatal,
+    SkipObject,
+}
+
+/// One error produced after a backend has already enumerated an object's
+/// handle. Keeping the handle and disposition internal lets the public MTP API
+/// remain backend-neutral while detailed collection callers still receive a
+/// useful diagnostic.
+#[derive(Debug)]
+pub(crate) struct BackendListingError {
+    pub(crate) handle: ObjectHandle,
+    pub(crate) source: Error,
+    pub(crate) disposition: ListingErrorDisposition,
+}
+
+impl BackendListingError {
+    pub(crate) fn fatal(handle: ObjectHandle, source: Error) -> Self {
+        Self {
+            handle,
+            source,
+            disposition: ListingErrorDisposition::Fatal,
+        }
+    }
+
+    pub(crate) fn skippable(handle: ObjectHandle, source: Error) -> Self {
+        Self {
+            handle,
+            source,
+            disposition: ListingErrorDisposition::SkipObject,
+        }
+    }
+}
+
 /// A boxed stream of object metadata, yielded by [`MtpBackend::list`].
-pub(crate) type ObjectStream = Pin<Box<dyn Stream<Item = Result<ObjectInfo, Error>> + Send>>;
+pub(crate) type ObjectStream =
+    Pin<Box<dyn Stream<Item = Result<ObjectInfo, BackendListingError>> + Send>>;
 
 /// One in-progress listing returned by [`MtpBackend::list`]: a known total plus the item stream.
 pub(crate) struct BackendListing {

--- a/crates/mtp-rs/src/mtp/backend/usb.rs
+++ b/crates/mtp-rs/src/mtp/backend/usb.rs
@@ -9,7 +9,8 @@
 
 use crate::cancel::{bail_if_cancelled, CancelToken};
 use crate::mtp::backend::{
-    BackendDownload, BackendListing, ByteRange, DownloadBody, MtpBackend, ProgressFn, UploadStream,
+    BackendDownload, BackendListing, BackendListingError, ByteRange, DownloadBody, MtpBackend,
+    ProgressFn, UploadStream,
 };
 use crate::mtp::object::NewObjectInfo;
 use crate::mtp::stream::Progress;
@@ -169,8 +170,11 @@ impl UsbBackend {
 ///
 /// Two shapes count as a decline:
 ///
-/// - `Protocol`: the spec'd way to say no (`OperationNotSupported`,
-///   `InvalidObjectHandle`, `InvalidParameter`, …).
+/// - Selected `Protocol` responses that explicitly reject the operation or its
+///   parent parameter (`OperationNotSupported`, `InvalidObjectHandle`,
+///   `InvalidParentObject`, `InvalidParameter`, `ParameterNotSupported`). A
+///   broad `GeneralError` is not a decline: enumeration integrity is unknown,
+///   so it propagates.
 /// - `Io`: how a bulk STALL arrives, which is how SIC-compliant cameras signal
 ///   an unsupported operation (Panasonic Lumix DMC-TZ61, #12). The transport
 ///   folds STALL in with `Fault`/`InvalidArgument`/`Unknown`, so `Io` can't be
@@ -178,7 +182,17 @@ impl UsbBackend {
 ///   permissive side deliberately, since losing camera root listings would be
 ///   the worse failure.
 fn is_all_handle_rejection(err: &PtpError) -> bool {
-    matches!(err, PtpError::Protocol { .. } | PtpError::Io(_))
+    matches!(
+        err,
+        PtpError::Protocol {
+            code: ResponseCode::OperationNotSupported
+                | ResponseCode::InvalidObjectHandle
+                | ResponseCode::InvalidParentObject
+                | ResponseCode::InvalidParameter
+                | ResponseCode::ParameterNotSupported,
+            ..
+        } | PtpError::Io(_)
+    )
 }
 
 /// How to filter objects by parent handle during a listing (PTP terms).
@@ -285,16 +299,35 @@ impl MtpBackend for UsbBackend {
 
                 // Cooperative cancel check before issuing the per-handle USB roundtrip. On a
                 // 1k-photo listing this is the actual stop point.
+                let handle = state.handles[state.cursor];
+
                 if let Err(e) = bail_if_cancelled(state.cancel.as_ref()) {
-                    return Some((Err(Error::from(e)), state));
+                    return Some((
+                        Err(BackendListingError::fatal(handle.into(), Error::from(e))),
+                        state,
+                    ));
                 }
 
-                let handle = state.handles[state.cursor];
                 state.cursor += 1;
 
                 let mut info = match state.session.get_object_info_full(handle).await {
                     Ok(info) => info,
-                    Err(e) => return Some((Err(Error::from(e)), state)),
+                    Err(e) => {
+                        let disposition = matches!(
+                            e,
+                            PtpError::Protocol {
+                                code: ResponseCode::GeneralError,
+                                operation: OperationCode::GetObjectInfo,
+                            }
+                        );
+                        let source = Error::from(e);
+                        let error = if disposition {
+                            BackendListingError::skippable(handle.into(), source)
+                        } else {
+                            BackendListingError::fatal(handle.into(), source)
+                        };
+                        return Some((Err(error), state));
+                    }
                 };
                 info.handle = handle;
 
@@ -579,6 +612,10 @@ mod tests {
             code: ResponseCode::OperationNotSupported,
             operation: OperationCode::GetObjectHandles,
         }));
+        assert!(is_all_handle_rejection(&PtpError::Protocol {
+            code: ResponseCode::InvalidParentObject,
+            operation: OperationCode::GetObjectHandles,
+        }));
         // ...and a bulk STALL is how SIC cameras say the same thing (#12). The
         // transport can only surface that as `Io`, so `Io` has to fall back too.
         assert!(is_all_handle_rejection(&PtpError::Io(
@@ -592,6 +629,10 @@ mod tests {
         // declining. Retrying hammers a sick device and reports the second
         // error, hiding the first.
         for err in [
+            PtpError::Protocol {
+                code: ResponseCode::GeneralError,
+                operation: OperationCode::GetObjectHandles,
+            },
             PtpError::DeviceReset,
             PtpError::Timeout,
             PtpError::Disconnected,
@@ -777,7 +818,7 @@ mod tests {
     async fn collect(mut listing: BackendListing) -> Result<Vec<ObjectInfo>, Error> {
         let mut out = Vec::new();
         while let Some(item) = listing.items.next().await {
-            out.push(item?);
+            out.push(item.map_err(|error| error.source)?);
         }
         Ok(out)
     }
@@ -871,6 +912,107 @@ mod tests {
         assert!(listing.items.next().await.unwrap().is_err());
     }
 
+    #[tokio::test]
+    async fn list_general_error_is_tolerated_only_by_collection() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "first.jpg", 0);
+        mock.queue_response(error_response(3, ResponseCode::GeneralError));
+        queue_object_info(&mock, 4, "last.jpg", 0);
+
+        let backend = mock_backend(transport, "").await;
+        let storage =
+            crate::mtp::Storage::new(Arc::new(backend), SID, crate::mtp::StorageInfo::default());
+        let collection = storage.list_objects_detailed(None).await.unwrap();
+
+        assert_eq!(collection.objects.len(), 2);
+        assert_eq!(collection.objects[0].filename, "first.jpg");
+        assert_eq!(collection.objects[1].filename, "last.jpg");
+        assert_eq!(collection.skipped.len(), 1);
+        assert_eq!(collection.skipped[0].handle, ObjectHandle(20));
+        assert!(matches!(
+            collection.skipped[0].error,
+            Error::Other { ref detail } if detail == "GeneralError"
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_objects_returns_valid_siblings_around_general_error() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "first.jpg", 0);
+        mock.queue_response(error_response(3, ResponseCode::GeneralError));
+        queue_object_info(&mock, 4, "last.jpg", 0);
+
+        let backend = mock_backend(transport, "").await;
+        let storage =
+            crate::mtp::Storage::new(Arc::new(backend), SID, crate::mtp::StorageInfo::default());
+        let objects = storage.list_objects(None).await.unwrap();
+
+        assert_eq!(objects.len(), 2);
+        assert_eq!(objects[0].filename, "first.jpg");
+        assert_eq!(objects[1].filename, "last.jpg");
+    }
+
+    #[tokio::test]
+    async fn stream_keeps_general_error_observable_and_continues() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        queue_handles(&mock, 1, &[10, 20, 30]);
+        queue_object_info(&mock, 2, "first.jpg", 0);
+        mock.queue_response(error_response(3, ResponseCode::GeneralError));
+        queue_object_info(&mock, 4, "last.jpg", 0);
+
+        let backend = mock_backend(transport, "").await;
+        let storage =
+            crate::mtp::Storage::new(Arc::new(backend), SID, crate::mtp::StorageInfo::default());
+        let mut listing = storage.list_objects_stream(None).await.unwrap();
+
+        assert_eq!(listing.next().await.unwrap().unwrap().filename, "first.jpg");
+        assert!(matches!(
+            listing.next().await.unwrap(),
+            Err(Error::Other { ref detail }) if detail == "GeneralError"
+        ));
+        assert_eq!(listing.next().await.unwrap().unwrap().filename, "last.jpg");
+        assert!(listing.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn invalid_object_handle_remains_fatal_for_collection() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        queue_handles(&mock, 1, &[10, 20]);
+        queue_object_info(&mock, 2, "first.jpg", 0);
+        mock.queue_response(error_response(3, ResponseCode::InvalidObjectHandle));
+
+        let backend = mock_backend(transport, "").await;
+        let storage =
+            crate::mtp::Storage::new(Arc::new(backend), SID, crate::mtp::StorageInfo::default());
+
+        assert!(matches!(
+            storage.list_objects_detailed(None).await,
+            Err(Error::StaleHandle)
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_enumeration_general_error_remains_fatal() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::GeneralError));
+
+        let backend = mock_backend(transport, "").await;
+        let storage =
+            crate::mtp::Storage::new(Arc::new(backend), SID, crate::mtp::StorageInfo::default());
+
+        assert!(matches!(
+            storage.list_objects_detailed(None).await,
+            Err(Error::Other { ref detail }) if detail == "GeneralError"
+        ));
+    }
+
     // -- Root fallback (Samsung) -------------------------------------------------
 
     #[tokio::test]
@@ -955,7 +1097,13 @@ mod tests {
         assert_eq!(listing.total, 3);
         cancel.cancel();
         let first = listing.items.next().await.expect("expected Some(Err)");
-        assert!(matches!(first, Err(Error::Cancelled)));
+        assert!(matches!(
+            first,
+            Err(BackendListingError {
+                source: Error::Cancelled,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]
@@ -972,7 +1120,13 @@ mod tests {
         assert_eq!(first.filename, "first.jpg");
         cancel.cancel();
         let second = listing.items.next().await.expect("expected Some(Err)");
-        assert!(matches!(second, Err(Error::Cancelled)));
+        assert!(matches!(
+            second,
+            Err(BackendListingError {
+                source: Error::Cancelled,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]

--- a/crates/mtp-rs/src/mtp/backend/wpd/mod.rs
+++ b/crates/mtp-rs/src/mtp/backend/wpd/mod.rs
@@ -140,7 +140,11 @@ impl MtpBackend for WpdBackend {
             })
             .await?;
         let total = objs.len();
-        let items = futures::stream::iter(objs.into_iter().map(Ok::<ObjectInfo, Error>)).boxed();
+        let items = futures::stream::iter(
+            objs.into_iter()
+                .map(Ok::<ObjectInfo, super::BackendListingError>),
+        )
+        .boxed();
         Ok(BackendListing { total, items })
     }
 

--- a/crates/mtp-rs/src/mtp/mod.rs
+++ b/crates/mtp-rs/src/mtp/mod.rs
@@ -51,7 +51,7 @@ pub use hotplug::{
 };
 // Backend-neutral high-level types (see types.rs). These are the default vocabulary for `mtp::`.
 pub use object::NewObjectInfo;
-pub use storage::{ObjectListing, Storage};
+pub use storage::{ObjectCollection, ObjectListing, SkippedObject, Storage};
 pub use stream::{
     FileDownload, Progress, WindowedDownload, DEFAULT_CANCEL_TIMEOUT, DEFAULT_DOWNLOAD_WINDOW,
 };

--- a/crates/mtp-rs/src/mtp/storage.rs
+++ b/crates/mtp-rs/src/mtp/storage.rs
@@ -1,7 +1,9 @@
 //! Storage operations (a thin façade over the active backend).
 
 use crate::cancel::{bail_if_cancelled, CancelToken};
-use crate::mtp::backend::{BackendListing, ByteRange, MtpBackend, ProgressFn};
+use crate::mtp::backend::{
+    BackendListing, BackendListingError, ByteRange, ListingErrorDisposition, MtpBackend, ProgressFn,
+};
 use crate::mtp::object::NewObjectInfo;
 use crate::mtp::stream::{FileDownload, Progress, WindowedDownload, DEFAULT_DOWNLOAD_WINDOW};
 use crate::mtp::{Error, ObjectHandle, ObjectInfo, StorageId, StorageInfo, UploadError};
@@ -67,14 +69,7 @@ impl ObjectListing {
         self.fetched
     }
 
-    /// Fetch the next object from the device.
-    ///
-    /// Returns `None` when the listing is exhausted. Items that don't match the parent filter are
-    /// skipped by the backend.
-    ///
-    /// If a [`CancelToken`] was passed via [`Storage::list_objects_stream_with_cancel`] and it's
-    /// been cancelled, this returns `Some(Err(Error::Cancelled))` at the next per-handle boundary.
-    pub async fn next(&mut self) -> Option<Result<ObjectInfo, Error>> {
+    async fn next_classified(&mut self) -> Option<Result<ObjectInfo, BackendListingError>> {
         match self.inner.items.next().await {
             Some(Ok(info)) => {
                 self.fetched += 1;
@@ -83,6 +78,38 @@ impl ObjectListing {
             other => other,
         }
     }
+
+    /// Fetch the next object from the device.
+    ///
+    /// Returns `None` when the listing is exhausted. Items that don't match the parent filter are
+    /// skipped by the backend.
+    ///
+    /// If a [`CancelToken`] was passed via [`Storage::list_objects_stream_with_cancel`] and it's
+    /// been cancelled, this returns `Some(Err(Error::Cancelled))` at the next per-handle boundary.
+    pub async fn next(&mut self) -> Option<Result<ObjectInfo, Error>> {
+        self.next_classified()
+            .await
+            .map(|result| result.map_err(|error| error.source))
+    }
+}
+
+/// A per-handle metadata failure that was safe to skip while collecting the
+/// other objects in the same directory.
+#[derive(Debug)]
+pub struct SkippedObject {
+    /// The object handle whose metadata request failed.
+    pub handle: ObjectHandle,
+    /// The backend-neutral error reported for that handle.
+    pub error: Error,
+}
+
+/// A completed tolerant directory collection.
+#[derive(Debug)]
+pub struct ObjectCollection {
+    /// Every object whose metadata was read successfully.
+    pub objects: Vec<ObjectInfo>,
+    /// Per-handle failures that met the library's narrow safe-to-skip policy.
+    pub skipped: Vec<SkippedObject>,
 }
 
 /// A storage location on an MTP device.
@@ -129,6 +156,12 @@ impl Storage {
     ///
     /// The backend handles device quirks (root-listing fast path and Android/Samsung/Fuji
     /// fallbacks).
+    ///
+    /// A narrowly tolerated per-object metadata rejection does not hide valid
+    /// siblings. Use [`list_objects_detailed`](Self::list_objects_detailed) to
+    /// retain its handle and diagnostic, or the streaming API to observe every
+    /// item error directly. All errors that can compromise enumeration or
+    /// session integrity remain fatal.
     pub async fn list_objects(
         &self,
         parent: Option<ObjectHandle>,
@@ -146,12 +179,57 @@ impl Storage {
         parent: Option<ObjectHandle>,
         cancel: Option<&CancelToken>,
     ) -> Result<Vec<ObjectInfo>, Error> {
+        Ok(self
+            .list_objects_detailed_with_cancel(parent, cancel)
+            .await?
+            .objects)
+    }
+
+    /// List objects and retain diagnostics for narrowly tolerated per-handle
+    /// metadata failures.
+    ///
+    /// Currently, only an explicit `GeneralError` response to one
+    /// `GetObjectInfo` request is tolerated. The handle list has already been
+    /// received, `GetObjectInfo` is read-only, and the protocol response closes
+    /// that transaction cleanly, so later siblings can still be queried.
+    /// Transport/session failures, malformed responses, cancellation, stale
+    /// handles, and every other error remain fatal.
+    pub async fn list_objects_detailed(
+        &self,
+        parent: Option<ObjectHandle>,
+    ) -> Result<ObjectCollection, Error> {
+        self.list_objects_detailed_with_cancel(parent, None).await
+    }
+
+    /// Like [`list_objects_detailed`](Self::list_objects_detailed), but with a
+    /// cooperative cancellation token.
+    pub async fn list_objects_detailed_with_cancel(
+        &self,
+        parent: Option<ObjectHandle>,
+        cancel: Option<&CancelToken>,
+    ) -> Result<ObjectCollection, Error> {
         let mut listing = self.list_objects_stream_with_cancel(parent, cancel).await?;
         let mut objects = Vec::with_capacity(listing.total());
-        while let Some(result) = listing.next().await {
-            objects.push(result?);
+        let mut skipped = Vec::new();
+        while let Some(result) = listing.next_classified().await {
+            match result {
+                Ok(object) => objects.push(object),
+                Err(error) if error.disposition == ListingErrorDisposition::SkipObject => {
+                    diag_debug!(
+                        "list_objects: skipping handle {} on storage {} after a completed per-object metadata error: {}",
+                        error.handle.0,
+                        self.id.0,
+                        error.source
+                    );
+                    skipped.push(SkippedObject {
+                        handle: error.handle,
+                        error: error.source,
+                    });
+                }
+                Err(error) => return Err(error.source),
+            }
         }
-        Ok(objects)
+        Ok(ObjectCollection { objects, skipped })
     }
 
     /// List objects in a folder as a streaming [`ObjectListing`].


### PR DESCRIPTION
## Problem

A completed `GetObjectInfo` request for one handle can return `GeneralError` while metadata for the remaining sibling handles is still readable. The current collection APIs fail the entire listing, hiding those valid siblings.

## Behavior

- Only a completed per-object `GetObjectInfo GeneralError` is classified as skippable.
- `list_objects` retains successfully read siblings.
- `list_objects_detailed` returns both valid objects and skipped-handle diagnostics.
- The streaming API remains item-oriented and exposes each error directly.
- Transport, session, cancellation, malformed-response, handle-enumeration, `InvalidObjectHandle`, and all other protocol failures remain fatal.
- No device-specific matching is introduced.

Closes #22.

## Tests

Targeted mock-transport tests cover valid siblings before and after the error, detailed diagnostics, streaming visibility and continuation, fatal `InvalidObjectHandle`, and fatal handle-enumeration failure. Formatting, strict clippy, tests, and documentation checks pass.

## Hardware validation

Hardware validation covered DBI and Sphaira. Sphaira returned a per-object `GeneralError` while other siblings remained readable; DBI provided a control case with no skipped objects. The tolerant collection retained all readable siblings while the streaming API continued exposing the individual error.

## Review question

This changes the default `list_objects` behavior while adding `list_objects_detailed` for callers that need diagnostics. Is `ObjectCollection { objects, skipped }` the preferred public API shape for that distinction?
