### PR TITLE
mtp: retry rejected root SendObjectInfo with storage ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Entries are grouped by release. Each entry tags which crate it applies to with *
 
 ## [Unreleased]
 
+### Fixed
+
+- **[lib] Root-level creates retry with the selected storage ID only when parent `0` receives `InvalidParentObject` or `InvalidObjectHandle` for that exact `SendObjectInfo` transaction.** The standard parent remains the first attempt, object data cannot start before the retry succeeds, nested writes are unchanged, and ambiguous transport/session failures are never retried.
+
 ## [0.29.0] - 2026-07-21
 
 Library `0.29.0`, CLI `0.7.4`. Recovering a wedged device stops being a CLI-only trick: consumers get the session-less reset, the error that says a reset happened now reaches them, and the diagnostic that captures the evidence finally runs on Android.

--- a/crates/mtp-rs/src/mtp/backend/usb.rs
+++ b/crates/mtp-rs/src/mtp/backend/usb.rs
@@ -103,6 +103,44 @@ impl UsbBackend {
         plan_partial_read(self.has_partial_object_64, self.has_partial_object, offset)
     }
 
+    /// Send metadata for a new object, preserving the standard root parent and
+    /// retrying only an explicit root-parent rejection that proves the first
+    /// metadata transaction completed before any object-data phase began. Some
+    /// responders require the selected storage ID in the parent command
+    /// parameter for root-level writes.
+    async fn send_object_info_with_root_fallback(
+        &self,
+        storage: PtpStorageId,
+        parent: Option<PtpHandle>,
+        info: &crate::ptp::ObjectInfo,
+    ) -> Result<(PtpStorageId, PtpHandle, PtpHandle), PtpError> {
+        let caller_requested_root = parent.is_none();
+        let first_parent = parent.unwrap_or(PtpHandle::ROOT);
+        match self
+            .session
+            .send_object_info(storage, first_parent, info)
+            .await
+        {
+            Err(error)
+                if caller_requested_root
+                    && first_parent == PtpHandle::ROOT
+                    && explicit_root_parent_rejection(&error).is_some() =>
+            {
+                let storage_parent = PtpHandle(storage.0);
+                let rejection = explicit_root_parent_rejection(&error)
+                    .expect("guard established an explicit root-parent rejection");
+                diag_debug!(
+                    "root-parent fallback: first SendObjectInfo returned {rejection:?}; retrying once with storage ID {}",
+                    storage.0
+                );
+                self.session
+                    .send_object_info(storage, storage_parent, info)
+                    .await
+            }
+            result => result,
+        }
+    }
+
     /// Resolve the object-handle list for a listing, applying the root-listing quirks.
     ///
     /// Returns `(handles, filter)` in PTP terms. Mirrors the historical `list_objects_stream`
@@ -154,6 +192,22 @@ impl UsbBackend {
             }
             Err(e) => Err(e),
         }
+    }
+}
+
+/// Classify the two completed protocol responses that some responders use to
+/// reject `parent=0` specifically for root-level `SendObjectInfo`.
+///
+/// This helper deliberately does not make either response generally retryable:
+/// its caller additionally proves the high-level parent was `None`, the first
+/// request used `PtpHandle::ROOT`, and no object-data phase can have started.
+fn explicit_root_parent_rejection(error: &PtpError) -> Option<ResponseCode> {
+    match error {
+        PtpError::Protocol {
+            code: code @ (ResponseCode::InvalidParentObject | ResponseCode::InvalidObjectHandle),
+            operation: OperationCode::SendObjectInfo,
+        } => Some(*code),
+        _ => None,
     }
 }
 
@@ -438,13 +492,15 @@ impl MtpBackend for UsbBackend {
     ) -> Result<ObjectHandle, UploadError> {
         let total_size = info.size;
         let object_info = info.to_object_info();
-        let parent_handle = parent.map(ObjectHandle::to_ptp).unwrap_or(PtpHandle::ROOT);
 
         // Phase 1: SendObjectInfo. No object exists yet, so a failure here has no partial to
         // surface.
         let (_, _, handle) = self
-            .session
-            .send_object_info(storage.to_ptp(), parent_handle, &object_info)
+            .send_object_info_with_root_fallback(
+                storage.to_ptp(),
+                parent.map(ObjectHandle::to_ptp),
+                &object_info,
+            )
             .await
             .map_err(|source| UploadError {
                 source: source.into(),
@@ -500,11 +556,13 @@ impl MtpBackend for UsbBackend {
     ) -> Result<ObjectHandle, Error> {
         let info = NewObjectInfo::folder(name);
         let object_info = info.to_object_info();
-        let parent_handle = parent.map(ObjectHandle::to_ptp).unwrap_or(PtpHandle::ROOT);
 
         let (_, _, handle) = self
-            .session
-            .send_object_info(storage.to_ptp(), parent_handle, &object_info)
+            .send_object_info_with_root_fallback(
+                storage.to_ptp(),
+                parent.map(ObjectHandle::to_ptp),
+                &object_info,
+            )
             .await?;
         Ok(handle.into())
     }
@@ -677,6 +735,36 @@ mod tests {
         buf.extend_from_slice(&pack_u16(code.into()));
         buf.extend_from_slice(&pack_u32(tx_id));
         buf
+    }
+
+    fn response_with_params(tx_id: u32, code: ResponseCode, params: &[u32]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(12 + params.len() * 4);
+        buf.extend_from_slice(&pack_u32((12 + params.len() * 4) as u32));
+        buf.extend_from_slice(&pack_u16(ContainerType::Response.to_code()));
+        buf.extend_from_slice(&pack_u16(code.into()));
+        buf.extend_from_slice(&pack_u32(tx_id));
+        for param in params {
+            buf.extend_from_slice(&pack_u32(*param));
+        }
+        buf
+    }
+
+    fn command_params(mock: &MockTransport, operation: OperationCode) -> Vec<Vec<u32>> {
+        let operation_code: u16 = operation.into();
+        mock.get_sends()
+            .into_iter()
+            .filter(|send| {
+                send.len() >= 12
+                    && u16::from_le_bytes([send[4], send[5]]) == ContainerType::Command.to_code()
+                    && u16::from_le_bytes([send[6], send[7]]) == operation_code
+            })
+            .map(|send| {
+                send[12..]
+                    .chunks_exact(4)
+                    .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                    .collect()
+            })
+            .collect()
     }
 
     fn data_container(tx_id: u32, code: OperationCode, payload: &[u8]) -> Vec<u8> {
@@ -869,6 +957,204 @@ mod tests {
         let first = listing.items.next().await.unwrap().unwrap();
         assert_eq!(first.filename, "good.jpg");
         assert!(listing.items.next().await.unwrap().is_err());
+    }
+
+    // -- Root-level SendObjectInfo fallback -------------------------------------
+
+    #[tokio::test]
+    async fn root_folder_uses_parent_zero_once_when_accepted() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(response_with_params(
+            1,
+            ResponseCode::Ok,
+            &[SID.0 as u32, 0, 77],
+        ));
+
+        let backend = mock_backend(transport, "").await;
+        let handle = backend.create_folder(SID, None, "folder").await.unwrap();
+
+        assert_eq!(handle, ObjectHandle(77));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0]]
+        );
+    }
+
+    #[tokio::test]
+    async fn root_folder_retries_once_after_invalid_parent_object() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::InvalidParentObject));
+        mock.queue_response(response_with_params(
+            2,
+            ResponseCode::Ok,
+            &[SID.0 as u32, SID.0 as u32, 77],
+        ));
+
+        let backend = mock_backend(transport, "").await;
+        let handle = backend.create_folder(SID, None, "folder").await.unwrap();
+
+        assert_eq!(handle, ObjectHandle(77));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0], vec![SID.0 as u32, SID.0 as u32]]
+        );
+    }
+
+    #[tokio::test]
+    async fn root_folder_retries_once_after_invalid_object_handle() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::InvalidObjectHandle));
+        mock.queue_response(response_with_params(
+            2,
+            ResponseCode::Ok,
+            &[SID.0 as u32, SID.0 as u32, 78],
+        ));
+
+        let backend = mock_backend(transport, "").await;
+        let handle = backend.create_folder(SID, None, "folder").await.unwrap();
+
+        assert_eq!(handle, ObjectHandle(78));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0], vec![SID.0 as u32, SID.0 as u32]]
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_success_starts_object_data_exactly_once() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::InvalidParentObject));
+        mock.queue_response(response_with_params(
+            2,
+            ResponseCode::Ok,
+            &[SID.0 as u32, SID.0 as u32, 88],
+        ));
+        mock.queue_response(ok_response(3));
+
+        let backend = mock_backend(transport, "").await;
+        let data = futures::stream::iter(vec![Ok(Bytes::from_static(b"data"))]);
+        let handle = backend
+            .upload(
+                SID,
+                None,
+                NewObjectInfo::file("file.bin", 4),
+                Box::pin(data),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(handle, ObjectHandle(88));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0], vec![SID.0 as u32, SID.0 as u32]]
+        );
+        assert_eq!(command_params(&mock, OperationCode::SendObject).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fallback_failure_has_no_third_attempt_or_data_phase() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::InvalidObjectHandle));
+        mock.queue_response(error_response(2, ResponseCode::InvalidParentObject));
+
+        let backend = mock_backend(transport, "").await;
+        let data = futures::stream::iter(vec![Ok(Bytes::from_static(b"data"))]);
+        let result = backend
+            .upload(
+                SID,
+                None,
+                NewObjectInfo::file("file.bin", 4),
+                Box::pin(data),
+                None,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(UploadError {
+                source: Error::StaleHandle,
+                partial: None
+            })
+        ));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0], vec![SID.0 as u32, SID.0 as u32]]
+        );
+        assert!(command_params(&mock, OperationCode::SendObject).is_empty());
+    }
+
+    #[tokio::test]
+    async fn nested_invalid_object_handle_never_uses_storage_fallback() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::InvalidObjectHandle));
+
+        let backend = mock_backend(transport, "").await;
+        let result = backend
+            .create_folder(SID, Some(ObjectHandle(42)), "folder")
+            .await;
+
+        assert!(matches!(result, Err(Error::StaleHandle)));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 42]]
+        );
+    }
+
+    #[tokio::test]
+    async fn root_session_failure_never_uses_storage_fallback() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::SessionNotOpen));
+
+        let backend = mock_backend(transport, "").await;
+        let result = backend.create_folder(SID, None, "folder").await;
+
+        assert!(matches!(result, Err(Error::Disconnected)));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0]]
+        );
+    }
+
+    #[tokio::test]
+    async fn root_general_error_never_uses_storage_fallback() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+        mock.queue_response(error_response(1, ResponseCode::GeneralError));
+
+        let backend = mock_backend(transport, "").await;
+        let result = backend.create_folder(SID, None, "folder").await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Other { ref detail }) if detail == "GeneralError"
+        ));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0]]
+        );
+    }
+
+    #[tokio::test]
+    async fn ambiguous_root_transport_failure_never_retries() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(ok_response(0));
+
+        let backend = mock_backend(transport, "").await;
+        let result = backend.create_folder(SID, None, "folder").await;
+
+        assert!(matches!(result, Err(Error::NoDevice)));
+        assert_eq!(
+            command_params(&mock, OperationCode::SendObjectInfo),
+            vec![vec![SID.0 as u32, 0]]
+        );
     }
 
     // -- Root fallback (Samsung) -------------------------------------------------


### PR DESCRIPTION
## Problem

Some responders reject a root-level `SendObjectInfo` using the standard parent value `0`, but accept the selected storage ID as the parent.

## Behavior

- Send root-level `SendObjectInfo` with parent `0` first.
- Retry exactly once with the selected storage ID only after a completed `InvalidParentObject` or `InvalidObjectHandle` response for that transaction.
- Apply the fallback only when the high-level caller requested the storage root.
- Do not retry nested writes or any other operation.
- Do not begin the object-data phase until metadata succeeds.
- Do not retry transport, timeout, cancellation, session, malformed-response, `GeneralError`, or other ambiguous failures.
- Do not change the general meaning of either rejection code.

Closes #21.

## Tests

Targeted mock-transport tests cover both accepted rejection codes, no retry after immediate success, exactly one data phase after fallback success, no third attempt after fallback failure, nested-parent behavior, and ambiguous failure propagation.

## Hardware validation

Hardware validation against DBI and Sphaira confirmed the root-parent incompatibility. Root `parent=0` was explicitly rejected with `InvalidObjectHandle` and, in an independent run, `InvalidParentObject`; the single storage-ID retry then succeeded, readback matched, and cleanup completed.

## Review question

Does treating these two completed `SendObjectInfo` responses as narrowly scoped root-parent rejections match the intended compatibility policy?
