### PR TITLE
Allow reusing an existing PTP session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ backend-agnostic variants (`NotFound`, `StaleHandle`, `AccessDenied`, `Unsupport
 `ptp::PtpError`); `ptp::` keeps its detailed response-code errors for camera/protocol users.
 
 **Entry points:** `MtpDevice::open_first()`, `PtpDevice::open_first()`, `NusbTransport::list_mtp_devices()`, `mtp::watch_devices()` (hotplug stream), `MtpDevice::reset_by_serial()` (session-less transport reset),
-`MtpDeviceBuilder::open_virtual()` (feature-gated)
+`MtpDeviceBuilder::open_virtual()` (feature-gated), `MtpDeviceBuilder::reuse_existing_session(id)`
+(USB-only opt-in for a stable session that survives across host processes)
 
 **Key types:** `ObjectHandle`, `StorageId` (opaque `u64` newtypes, session-scoped tokens — not wire
 values), `ObjectFormat` (raw MTP format code + category helpers), `Capabilities` (replaces the old
@@ -113,6 +114,11 @@ range, window_size)` (returns `WindowedDownload`), and buffered `Storage::downlo
 - **Fujifilm cameras**: Report `AccessCapability::ReadWrite` but return `StoreReadOnly` on writes. Advertised ops lie.
 - **Samsung**: Returns `InvalidObjectHandle` for root listing; needs recursive traversal with filtering
 - **Panasonic Lumix DMC-TZ61** (and likely other PTP cameras): Reports `20480000T000000` (month 0, day 0) as "no date" in ObjectInfo datetimes. Receive-side datetime parsing is lenient for this reason: unparseable datetimes become `None` instead of failing the dataset parse. Send-side packing stays strict.
+- **Teenage Engineering TP-7**: Keeps its device-side MTP session open across host processes and treats
+  `CloseSession` as a request to leave MTP mode. Use
+  `MtpDeviceBuilder::reuse_existing_session(0xBAAA_AAAD)` to reuse its stable session without sending
+  `CloseSession` when `OpenSession` reports `SessionAlreadyOpen`. Dropping `MtpDevice` leaves the session
+  alone; explicitly calling `MtpDevice::close()` still sends `CloseSession` and exits MTP mode.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,10 @@ range, window_size)` (returns `WindowedDownload`), and buffered `Storage::downlo
   `MtpDeviceBuilder::reuse_existing_session(0xBAAA_AAAD)` to reuse its stable session without sending
   `CloseSession` when `OpenSession` reports `SessionAlreadyOpen`. Dropping `MtpDevice` leaves the session
   alone; explicitly calling `MtpDevice::close()` still sends `CloseSession` and exits MTP mode.
+  **Hardware-verified A/B on TP-7 firmware 2.5.7 / MTP 1.1.11** (macOS/nusb, 2026-08-27): with
+  session reuse disabled, the first CLI process succeeded and the second found the recorder back in
+  `audio-midi` mode; with reuse enabled, two consecutive CLI processes both succeeded and left it in
+  `mtp` mode.
 
 ## Testing
 

--- a/crates/mtp-rs/src/mtp/device.rs
+++ b/crates/mtp-rs/src/mtp/device.rs
@@ -443,6 +443,7 @@ pub struct MtpDeviceBuilder {
     timeout: Duration,
     known_devices: Vec<(u16, u16)>,
     backend: Backend,
+    reuse_existing_session_id: Option<u32>,
 }
 
 impl MtpDeviceBuilder {
@@ -452,6 +453,7 @@ impl MtpDeviceBuilder {
             timeout: NusbTransport::DEFAULT_TIMEOUT,
             known_devices: Vec::new(),
             backend: Backend::default(),
+            reuse_existing_session_id: None,
         }
     }
 
@@ -581,6 +583,28 @@ impl MtpDeviceBuilder {
         self
     }
 
+    /// Reuse a device-side PTP session with the given stable ID when it is already open.
+    ///
+    /// The default open behavior closes an existing session and starts a fresh one. This opt-in is
+    /// for USB devices that persist a session across host processes and accept the transaction
+    /// counter restarting from one. It prevents the open path from sending `CloseSession` after a
+    /// `SessionAlreadyOpen` response.
+    #[must_use]
+    pub fn reuse_existing_session(mut self, session_id: u32) -> Self {
+        self.reuse_existing_session_id = Some(session_id);
+        self
+    }
+
+    async fn open_ptp_session(
+        &self,
+        transport: Arc<dyn Transport>,
+    ) -> Result<PtpSession, crate::PtpError> {
+        match self.reuse_existing_session_id {
+            Some(session_id) => PtpSession::open_reusing_existing(transport, session_id).await,
+            None => PtpSession::open(transport, 1).await,
+        }
+    }
+
     /// Open the first available device.
     pub async fn open_first(self) -> Result<MtpDevice, Error> {
         if let Some(device) = self.try_open_wpd_first().await? {
@@ -697,8 +721,7 @@ impl MtpDeviceBuilder {
         let transport = NusbTransport::open_with_timeout(device, self.timeout).await?;
         let transport: Arc<dyn Transport> = Arc::new(transport);
 
-        // Open session (use session ID 1)
-        let session = Arc::new(PtpSession::open(transport.clone(), 1).await?);
+        let session = Arc::new(self.open_ptp_session(transport.clone()).await?);
 
         // Get device info
         let device_info = session.get_device_info().await?;
@@ -828,8 +851,7 @@ impl MtpDeviceBuilder {
         let transport = crate::transport::virtual_device::VirtualTransport::new(config);
         let transport: Arc<dyn Transport> = Arc::new(transport);
 
-        // Open session (use session ID 1)
-        let session = Arc::new(PtpSession::open(transport.clone(), 1).await?);
+        let session = Arc::new(self.open_ptp_session(transport.clone()).await?);
 
         // Get device info
         let device_info = session.get_device_info().await?;
@@ -901,6 +923,12 @@ mod tests {
         // Custom value
         let custom = MtpDeviceBuilder::new().timeout(Duration::from_secs(45));
         assert_eq!(custom.timeout, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn builder_reuses_existing_session() {
+        let builder = MtpDeviceBuilder::new().reuse_existing_session(0xBAAA_AAAD);
+        assert_eq!(builder.reuse_existing_session_id, Some(0xBAAA_AAAD));
     }
 
     #[test]

--- a/crates/mtp-rs/src/mtp/device.rs
+++ b/crates/mtp-rs/src/mtp/device.rs
@@ -307,7 +307,11 @@ impl MtpDevice {
         self.backend.next_event().await
     }
 
-    /// Close the connection (best-effort; also happens on drop).
+    /// Explicitly close the connection.
+    ///
+    /// On the USB backend this sends a best-effort `CloseSession`; dropping [`MtpDevice`] does not.
+    /// This still applies after [`MtpDeviceBuilder::reuse_existing_session`]. On devices such as the
+    /// Teenage Engineering TP-7, an explicit close makes the device leave MTP mode.
     pub async fn close(self) -> Result<(), Error> {
         self.backend.close().await
     }
@@ -467,6 +471,16 @@ impl MtpDeviceBuilder {
         self
     }
 
+    #[cfg(windows)]
+    fn diagnose_reuse_ignored_by_wpd(&self) {
+        if let Some(session_id) = self.reuse_existing_session_id {
+            diag_debug!(
+                "reuse_existing_session({}) ignored because the selected WPD backend does not use PTP sessions",
+                session_id
+            );
+        }
+    }
+
     /// If the configured backend selects WPD (Windows), try to open the first WPD device.
     ///
     /// Returns `Ok(None)` when WPD isn't selected, or when `Auto` found no WPD device (so the caller
@@ -476,9 +490,10 @@ impl MtpDeviceBuilder {
         if matches!(self.backend, Backend::Auto | Backend::Wpd) {
             match crate::mtp::backend::wpd::WpdBackend::open_first().await {
                 Ok(b) => {
+                    self.diagnose_reuse_ignored_by_wpd();
                     return Ok(Some(MtpDevice {
                         backend: Arc::new(b),
-                    }))
+                    }));
                 }
                 Err(e) if self.backend == Backend::Wpd || !matches!(e, Error::NoDevice) => {
                     return Err(e)
@@ -499,9 +514,10 @@ impl MtpDeviceBuilder {
         if matches!(self.backend, Backend::Auto | Backend::Wpd) {
             match crate::mtp::backend::wpd::WpdBackend::open_by_serial(serial).await {
                 Ok(b) => {
+                    self.diagnose_reuse_ignored_by_wpd();
                     return Ok(Some(MtpDevice {
                         backend: Arc::new(b),
-                    }))
+                    }));
                 }
                 Err(e) if self.backend == Backend::Wpd || !matches!(e, Error::NoDevice) => {
                     return Err(e)
@@ -536,9 +552,10 @@ impl MtpDeviceBuilder {
             match crate::mtp::backend::wpd::WpdBackend::open_for_usb(serial.clone(), vid, pid).await
             {
                 Ok(b) => {
+                    self.diagnose_reuse_ignored_by_wpd();
                     return Ok(Some(MtpDevice {
                         backend: Arc::new(b),
-                    }))
+                    }));
                 }
                 Err(e) if self.backend == Backend::Wpd || !matches!(e, Error::NoDevice) => {
                     return Err(e)
@@ -589,6 +606,10 @@ impl MtpDeviceBuilder {
     /// for USB devices that persist a session across host processes and accept the transaction
     /// counter restarting from one. It prevents the open path from sending `CloseSession` after a
     /// `SessionAlreadyOpen` response.
+    ///
+    /// This setting applies only to the USB backend. It is ignored if [`Backend::Auto`] selects WPD
+    /// on Windows, or when [`Backend::Wpd`] is selected explicitly. Calling [`MtpDevice::close`]
+    /// still sends `CloseSession` on USB; drop the device instead when its session must remain open.
     #[must_use]
     pub fn reuse_existing_session(mut self, session_id: u32) -> Self {
         self.reuse_existing_session_id = Some(session_id);
@@ -925,10 +946,46 @@ mod tests {
         assert_eq!(custom.timeout, Duration::from_secs(45));
     }
 
-    #[test]
-    fn builder_reuses_existing_session() {
-        let builder = MtpDeviceBuilder::new().reuse_existing_session(0xBAAA_AAAD);
-        assert_eq!(builder.reuse_existing_session_id, Some(0xBAAA_AAAD));
+    #[cfg(feature = "virtual-device")]
+    #[tokio::test]
+    async fn builder_reuses_existing_session_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = crate::VirtualDeviceConfig {
+            model: "Session Reuse Test".into(),
+            serial: "session-reuse-test".into(),
+            storages: vec![crate::VirtualStorageConfig {
+                description: "Internal Storage".into(),
+                capacity: 1024,
+                backing_dir: dir.path().to_path_buf(),
+                read_only: false,
+            }],
+            event_poll_interval: Duration::ZERO,
+            watch_backing_dirs: false,
+            ..Default::default()
+        };
+        let transport: Arc<dyn Transport> = Arc::new(
+            crate::transport::virtual_device::VirtualTransport::new(config),
+        );
+        let session_id = 0xBAAA_AAAD;
+
+        let first = MtpDeviceBuilder::new()
+            .reuse_existing_session(session_id)
+            .open_ptp_session(transport.clone())
+            .await
+            .unwrap();
+        drop(first);
+
+        let reused = MtpDeviceBuilder::new()
+            .reuse_existing_session(session_id)
+            .open_ptp_session(transport)
+            .await
+            .unwrap();
+
+        assert_eq!(reused.session_id().0, session_id);
+        assert_eq!(
+            reused.get_device_info().await.unwrap().model,
+            "Session Reuse Test"
+        );
     }
 
     #[test]

--- a/crates/mtp-rs/src/ptp/session/mod.rs
+++ b/crates/mtp-rs/src/ptp/session/mod.rs
@@ -211,6 +211,27 @@ impl PtpSession {
     ///
     /// Returns an error if the device rejects the session or communication fails.
     pub async fn open(transport: Arc<dyn Transport>, session_id: u32) -> Result<Self, Error> {
+        Self::open_with_reuse(transport, session_id, false).await
+    }
+
+    /// Open a session without closing a matching device-side session that already exists.
+    ///
+    /// This is for devices that keep a session open across host processes and accept the
+    /// transaction counter restarting from one. Unlike [`open`](Self::open), a
+    /// [`ResponseCode::SessionAlreadyOpen`] response is treated as success and no `CloseSession`
+    /// command is sent.
+    pub async fn open_reusing_existing(
+        transport: Arc<dyn Transport>,
+        session_id: u32,
+    ) -> Result<Self, Error> {
+        Self::open_with_reuse(transport, session_id, true).await
+    }
+
+    async fn open_with_reuse(
+        transport: Arc<dyn Transport>,
+        session_id: u32,
+        reuse_existing: bool,
+    ) -> Result<Self, Error> {
         let session = Self::new(transport, SessionId(session_id));
 
         // PTP spec: OpenSession is a session-less operation, so use tx_id=0.
@@ -223,6 +244,14 @@ impl PtpSession {
         }
 
         if response.code == ResponseCode::SessionAlreadyOpen {
+            if reuse_existing {
+                diag_debug!(
+                    "open: device reports SessionAlreadyOpen (id={}); reusing existing session",
+                    session_id
+                );
+                return Ok(session);
+            }
+
             diag_debug!(
                 "open: device reports SessionAlreadyOpen (id={}); closing and reopening. \
                  If this persists right after a cancel-wedge reset (#18), the caller reopened \
@@ -728,6 +757,23 @@ mod tests {
         // Should succeed by closing and reopening
         let session = PtpSession::open(transport, 1).await.unwrap();
         assert_eq!(session.session_id(), SessionId(1));
+    }
+
+    #[tokio::test]
+    async fn test_open_session_already_open_reuses_without_close() {
+        let (transport, mock) = mock_transport();
+        mock.queue_response(response_with_params(
+            0,
+            ResponseCode::SessionAlreadyOpen,
+            &[],
+        ));
+
+        let session = PtpSession::open_reusing_existing(transport, 0xBAAA_AAAD)
+            .await
+            .unwrap();
+
+        assert_eq!(session.session_id(), SessionId(0xBAAA_AAAD));
+        assert_eq!(mock.get_sends().len(), 1, "must not send CloseSession");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Teenage Engineering TP-7 firmware treats `CloseSession` as a request to leave MTP mode. Its companion workflow instead uses a stable session ID across host processes and continues when `OpenSession` reports `SessionAlreadyOpen`.

The current `mtp-rs` recovery path closes and reopens any existing session. That makes one-process-per-command TP-7 clients knock the recorder out of MTP mode after ordinary file operations. This behavior is needed by the TP-7 CLI work in https://github.com/totocaster/tp7/pull/4.

## Changes

- add `PtpSession::open_reusing_existing` for the low-level opt-in
- add `MtpDeviceBuilder::reuse_existing_session(id)` as the single high-level setting for a stable session ID plus reuse
- keep the existing close-and-reopen behavior as the default
- document that the setting is USB-only and that explicit `MtpDevice::close()` still sends `CloseSession`
- emit a diagnostic when Windows selects WPD and ignores the USB session setting
- document the TP-7 quirk, API, and hardware evidence in `AGENTS.md`
- add a mock regression test proving the reuse path sends no `CloseSession` command
- add an end-to-end virtual-transport test proving the builder threads the setting into the open path

No TP-7 identifiers or automatic device quirks are added to `mtp-rs`.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --quiet -- -D warnings`
- `cargo test --quiet -- --skip fs_watcher` (460 passed; 26 expected hardware/platform tests ignored; 6 watcher tests filtered into the separate pass)
- `cargo test --all-features --quiet -- --skip fs_watcher` (471 passed; 26 expected hardware/platform tests ignored; 6 watcher tests filtered into the separate pass)
- `cargo test --all-features --quiet fs_watcher -- --test-threads=1` (6 passed outside the sandbox)
- `cargo doc --no-deps --quiet`

## Hardware A/B

Hardware-verified on a TP-7 running device firmware 2.5.7 and MTP firmware 1.1.11 over macOS/nusb on 2026-08-27, with the documented `ptpcamerad` blocker active.

The control and patched binaries were built from the same TP-7 CLI commit (`503577d`). The control differed only by changing `reuse_existing_session(true)` to `reuse_existing_session(false)`; both used the same stable session ID (`0xBAAA_AAAD`).

- Patched `tp7 --json status` established the recorder in `mtp` mode.
- The first control `tp7 --json status` succeeded.
- The second independent control process exited 3: `TP-7 ... is in audio-midi mode; no MTP-compatible interface is visible`.
- Patched `tp7 --json --auto-connect connect` reported `initial_mode: audio-midi`, `final_mode: mtp`, `mtp_ready: true`.
- Two subsequent independent patched `tp7 --json status` processes both succeeded and reported `mode: mtp`.

This A/B used only mode switching and read-only status queries. No files or recordings were transferred, changed, or deleted, and no explicit `eject`/`CloseSession` was sent after the patched run.

The Rust 1.85 MSRV check is not available locally because this machine has a single Homebrew Rust toolchain and no `rustup`; the prior PR revision passed the upstream Rust 1.85 CI jobs on Linux, macOS, and Windows.